### PR TITLE
fix(cnpg): require cross-node database placement

### DIFF
--- a/clusters/main/kubernetes/apps/authentik/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/authentik/app/helm-release.yaml
@@ -29,6 +29,20 @@ spec:
       retries: 3
   uninstall:
     keepHistory: false
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              group: postgresql.cnpg.io
+              version: v1
+              kind: Cluster
+            patch: |-
+              - op: add
+                path: /spec/affinity
+                value:
+                  enablePodAntiAffinity: true
+                  topologyKey: kubernetes.io/hostname
+                  podAntiAffinityType: required
   values:
     global:
       stopAll: false

--- a/clusters/main/kubernetes/apps/gatus/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/gatus/app/helm-release.yaml
@@ -25,6 +25,20 @@ spec:
     crds: CreateReplace
     remediation:
       retries: 3
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              group: postgresql.cnpg.io
+              version: v1
+              kind: Cluster
+            patch: |-
+              - op: add
+                path: /spec/affinity
+                value:
+                  enablePodAntiAffinity: true
+                  topologyKey: kubernetes.io/hostname
+                  podAntiAffinityType: required
   values:
     portal:
       open:

--- a/clusters/main/kubernetes/apps/gitea/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/gitea/app/helm-release.yaml
@@ -29,6 +29,20 @@ spec:
       retries: 3
   uninstall:
     keepHistory: false
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              group: postgresql.cnpg.io
+              version: v1
+              kind: Cluster
+            patch: |-
+              - op: add
+                path: /spec/affinity
+                value:
+                  enablePodAntiAffinity: true
+                  topologyKey: kubernetes.io/hostname
+                  podAntiAffinityType: required
   values:
     resources:
       limits:

--- a/clusters/main/kubernetes/apps/grafana/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/grafana/app/helm-release.yaml
@@ -29,6 +29,20 @@ spec:
       retries: 3
   uninstall:
     keepHistory: false
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              group: postgresql.cnpg.io
+              version: v1
+              kind: Cluster
+            patch: |-
+              - op: add
+                path: /spec/affinity
+                value:
+                  enablePodAntiAffinity: true
+                  topologyKey: kubernetes.io/hostname
+                  podAntiAffinityType: required
   values:
     global:
       stopAll: false

--- a/clusters/main/kubernetes/apps/home-assistant/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/home-assistant/app/helm-release.yaml
@@ -29,6 +29,20 @@ spec:
       retries: 3
   uninstall:
     keepHistory: false
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              group: postgresql.cnpg.io
+              version: v1
+              kind: Cluster
+            patch: |-
+              - op: add
+                path: /spec/affinity
+                value:
+                  enablePodAntiAffinity: true
+                  topologyKey: kubernetes.io/hostname
+                  podAntiAffinityType: required
   values:
     global:
       stopAll: false

--- a/clusters/main/kubernetes/apps/immich/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/immich/app/helm-release.yaml
@@ -29,6 +29,20 @@ spec:
       retries: 3
   uninstall:
     keepHistory: false
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              group: postgresql.cnpg.io
+              version: v1
+              kind: Cluster
+            patch: |-
+              - op: add
+                path: /spec/affinity
+                value:
+                  enablePodAntiAffinity: true
+                  topologyKey: kubernetes.io/hostname
+                  podAntiAffinityType: required
   values:
     global:
       stopAll: false

--- a/clusters/main/kubernetes/apps/kitchenowl/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/kitchenowl/app/helm-release.yaml
@@ -25,6 +25,20 @@ spec:
     crds: CreateReplace
     remediation:
       retries: 3
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              group: postgresql.cnpg.io
+              version: v1
+              kind: Cluster
+            patch: |-
+              - op: add
+                path: /spec/affinity
+                value:
+                  enablePodAntiAffinity: true
+                  topologyKey: kubernetes.io/hostname
+                  podAntiAffinityType: required
   values:
     global:
       stopAll: false

--- a/clusters/main/kubernetes/apps/nextcloud/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/nextcloud/app/helm-release.yaml
@@ -28,6 +28,20 @@ spec:
       retries: 3
   uninstall:
     keepHistory: false
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              group: postgresql.cnpg.io
+              version: v1
+              kind: Cluster
+            patch: |-
+              - op: add
+                path: /spec/affinity
+                value:
+                  enablePodAntiAffinity: true
+                  topologyKey: kubernetes.io/hostname
+                  podAntiAffinityType: required
   values:
     global:
       stopAll: false

--- a/clusters/main/kubernetes/apps/teslamate/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/teslamate/app/helm-release.yaml
@@ -14,6 +14,20 @@ spec:
         name: truecharts
         namespace: flux-system
 
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              group: postgresql.cnpg.io
+              version: v1
+              kind: Cluster
+            patch: |-
+              - op: add
+                path: /spec/affinity
+                value:
+                  enablePodAntiAffinity: true
+                  topologyKey: kubernetes.io/hostname
+                  podAntiAffinityType: required
   values:
     TZ: America/Los_Angeles
     cnpg:

--- a/clusters/main/kubernetes/apps/vaultwarden/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/vaultwarden/app/helm-release.yaml
@@ -29,6 +29,20 @@ spec:
       retries: 3
   uninstall:
     keepHistory: false
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              group: postgresql.cnpg.io
+              version: v1
+              kind: Cluster
+            patch: |-
+              - op: add
+                path: /spec/affinity
+                value:
+                  enablePodAntiAffinity: true
+                  topologyKey: kubernetes.io/hostname
+                  podAntiAffinityType: required
   values:
     TZ: America/Los_Angeles
     cnpg:


### PR DESCRIPTION
## Summary
- add Flux Helm post-renderer patches to all ten CNPG-backed applications
- require CNPG instances to use hostname-level pod anti-affinity
- keep production PodDisruptionBudgets enabled while ensuring a standby is placed on the other node

## Why
TUPPR node drains can encounter a CNPG primary PDB with zero allowed disruptions. Several two-instance CNPG clusters were using preferred anti-affinity, which allowed both instances to land on the same node and left no cross-node standby available for switchover.

## Validation
- [x] `git diff --check`
- [x] all ten HelmRelease manifests accepted by `kubectl apply --dry-run=server`
- [x] repository pre-commit encryption check passed

## Follow-up
This improves workload placement but does not itself fix TUPPR's immediate failure on a transient PDB rejection; that controller behavior should be handled separately.
