### PR TITLE
fix(cluster): rebalance workloads and size Prometheus

### DIFF
--- a/clusters/main/kubernetes/kube-system/descheduler/app/helm-release.yaml
+++ b/clusters/main/kubernetes/kube-system/descheduler/app/helm-release.yaml
@@ -40,6 +40,26 @@ spec:
                 evictFailedBarePods: true
                 evictLocalStoragePods: true
                 evictSystemCriticalPods: true
+            - name: LowNodeUtilization
+              args:
+                thresholds:
+                  cpu: 20
+                  memory: 20
+                  pods: 20
+                targetThresholds:
+                  cpu: 50
+                  memory: 50
+                  pods: 50
+                # Move at most one pod from an overloaded node per 5-minute
+                # descheduler cycle to avoid a burst of Longhorn detach/attach operations.
+                evictionLimits:
+                  node: 1
+                evictableNamespaces:
+                  exclude:
+                    - flux-system
+                    - kube-system
+                    - longhorn-system
+                    - system-upgrade
             - name: RemoveFailedPods
               args:
                 reasons:
@@ -62,6 +82,7 @@ spec:
           plugins:
             balance:
               enabled:
+                - LowNodeUtilization
                 - RemovePodsViolatingTopologySpreadConstraint
             deschedule:
               enabled:

--- a/clusters/main/kubernetes/observability/kube-prometheus-stack/app/helm-release.yaml
+++ b/clusters/main/kubernetes/observability/kube-prometheus-stack/app/helm-release.yaml
@@ -465,10 +465,10 @@ spec:
         replicas: 1
         resources:
           requests:
-            cpu: 100m
-            memory: 500Mi
+            cpu: 500m
+            memory: 2Gi
           limits:
-            memory: 2000Mi
+            memory: 4Gi
         storageSpec:
           volumeClaimTemplate:
             spec:


### PR DESCRIPTION
## Summary
- enable the Descheduler `LowNodeUtilization` balance plugin with thresholds matching the current two-node imbalance
- limit rebalancing to one eviction per overloaded node per five-minute cycle to avoid a burst of Longhorn detach/attach operations
- exclude core control-plane, Flux, Longhorn, and upgrade namespaces from utilization-based eviction
- raise Prometheus requests from 100m CPU / 500Mi memory to 500m CPU / 2Gi memory
- raise the Prometheus memory limit from 2000Mi to 4Gi

## Context
After the Talos maintenance, `k8s-control-1` retained 144 running pods and 78 attached Longhorn volumes while `k8s-worker-1` had 19 pods and two attached volumes. The current requested-resource utilization is approximately:

| Node | CPU requests | Memory requests | Pod capacity |
|---|---:|---:|---:|
| k8s-control-1 | 77.7% | 48.7% | 57.6% |
| k8s-worker-1 | 17.1% | 6.3% | 7.6% |

The 20% underutilized and 50% target thresholds therefore identify the worker as underutilized and the control node as overutilized. Existing PDB protections remain in effect.

Prometheus is currently using about 1.76Gi of its 2Gi memory limit while evaluating approximately 232k active series. The increased resources provide memory headroom and make scheduler accounting reflect its actual CPU usage more accurately.

## Validation
- `git diff --check`
- both HelmRelease resources passed `kubectl apply --dry-run=server`
- rendered Descheduler chart 0.36.0 and verified the generated `LowNodeUtilization` policy, namespace exclusions, and one-pod eviction limit
- rendered kube-prometheus-stack chart 87.16.0 and verified the Prometheus resource requests and limits
- repository pre-commit encryption checks passed

## Operational note
The Prometheus resource change will recreate its pod once after reconciliation. Descheduler rebalancing is intentionally gradual: at most one pod from an overloaded node every five minutes.