### PR TITLE
fix(cnpg): enable Prometheus database metrics

### DIFF
--- a/clusters/main/kubernetes/apps/authentik/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/authentik/app/helm-release.yaml
@@ -56,6 +56,8 @@ spec:
           token: ${AUTHENTIK_LDAP_TOKEN}
     cnpg:
       main:
+        monitoring:
+          enablePodMonitor: true
         backups:
           credentials: b2
           enabled: true

--- a/clusters/main/kubernetes/apps/gatus/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/gatus/app/helm-release.yaml
@@ -26,6 +26,10 @@ spec:
     remediation:
       retries: 3
   values:
+    cnpg:
+      main:
+        monitoring:
+          enablePodMonitor: true
     portal:
       open:
         enabled: false

--- a/clusters/main/kubernetes/apps/gitea/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/gitea/app/helm-release.yaml
@@ -42,6 +42,8 @@ spec:
       username: brock
     cnpg:
       main:
+        monitoring:
+          enablePodMonitor: true
         backups:
           credentials: b2
           enabled: true

--- a/clusters/main/kubernetes/apps/grafana/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/grafana/app/helm-release.yaml
@@ -35,6 +35,8 @@ spec:
     TZ: America/Los_Angeles
     cnpg:
       main:
+        monitoring:
+          enablePodMonitor: true
         backups:
           credentials: b2
           enabled: true

--- a/clusters/main/kubernetes/apps/home-assistant/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/home-assistant/app/helm-release.yaml
@@ -41,6 +41,8 @@ spec:
       trusted_proxies: ["172.16.0.0/16"]
     cnpg:
       main:
+        monitoring:
+          enablePodMonitor: true
         mode: recovery
         backups:
           enabled: true

--- a/clusters/main/kubernetes/apps/immich/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/immich/app/helm-release.yaml
@@ -35,6 +35,8 @@ spec:
     TZ: America/Los_Angeles
     cnpg:
       main:
+        monitoring:
+          enablePodMonitor: true
         backups:
           enabled: true
           credentials: b2

--- a/clusters/main/kubernetes/apps/kitchenowl/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/kitchenowl/app/helm-release.yaml
@@ -65,6 +65,8 @@ spec:
               schedule: 20 0 * * *
     cnpg:
       main:
+        monitoring:
+          enablePodMonitor: true
         mode: recovery
         backups:
           enabled: true

--- a/clusters/main/kubernetes/apps/nextcloud/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/nextcloud/app/helm-release.yaml
@@ -34,6 +34,8 @@ spec:
     TZ: America/Los_Angeles
     cnpg:
       main:
+        monitoring:
+          enablePodMonitor: true
         backups:
           credentials: b2
           enabled: true

--- a/clusters/main/kubernetes/apps/teslamate/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/teslamate/app/helm-release.yaml
@@ -18,6 +18,8 @@ spec:
     TZ: America/Los_Angeles
     cnpg:
       main:
+        monitoring:
+          enablePodMonitor: true
         mode: recovery
         backups:
           enabled: true

--- a/clusters/main/kubernetes/apps/vaultwarden/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/vaultwarden/app/helm-release.yaml
@@ -33,6 +33,8 @@ spec:
     TZ: America/Los_Angeles
     cnpg:
       main:
+        monitoring:
+          enablePodMonitor: true
         backups:
           credentials: b2
           enabled: true


### PR DESCRIPTION
## Summary

- enable the TrueCharts CNPG `PodMonitor` integration for all ten PostgreSQL-backed applications
- allow the CloudNativePG operator to create database PodMonitors targeting each cluster's metrics endpoint
- restore `cnpg_*` series discovery in Prometheus so the CloudNativePG Grafana dashboard can populate

## Root cause

The operator-level `monitoring.podMonitorEnabled` setting only monitors the CloudNativePG operator. Every application `Cluster` rendered with `spec.monitoring.enablePodMonitor: false`, leaving Prometheus with zero CNPG database targets and zero `cnpg_*` series even though the pod metrics endpoints on port 9187 were healthy.

## Validation

- [x] All ten modified HelmRelease resources passed `kubectl apply --dry-run=server`
- [x] All ten application charts rendered successfully with their pinned chart versions
- [x] Every rendered CNPG `Cluster` has `spec.monitoring.enablePodMonitor: true`
- [x] `kubectl kustomize clusters/main/kubernetes/apps` completed successfully
- [x] `git diff --check` passed
- [x] Repository pre-commit encryption checks passed

## Post-merge verification

After Flux reconciles, verify that each application namespace contains a CNPG PodMonitor, that Prometheus reports the corresponding targets as healthy, and that queries for `cnpg_*` metrics return data.
