### PR TITLE
fix(flux): scope GitHub commit statuses

### DIFF
--- a/clusters/main/kubernetes/flux-system/notifications/github/provider.yaml
+++ b/clusters/main/kubernetes/flux-system/notifications/github/provider.yaml
@@ -24,3 +24,5 @@ spec:
   eventSources:
     - kind: Kustomization
       name: '*'
+      matchLabels:
+        notification.toolkit.fluxcd.io/github-status: enabled

--- a/clusters/main/kubernetes/kustomization.yaml
+++ b/clusters/main/kubernetes/kustomization.yaml
@@ -9,3 +9,22 @@ resources:
   - networking
   - system
   - observability
+patches:
+  # GitHub commit statuses are only valid for Kustomizations sourced from
+  # this repository. Label all repository-managed Kustomizations, then remove
+  # the label from the Flux controller Kustomization sourced from upstream OCI.
+  - target:
+      kind: Kustomization
+    patch: |-
+      apiVersion: kustomize.toolkit.fluxcd.io/v1
+      kind: Kustomization
+      metadata:
+        name: not-used
+        labels:
+          notification.toolkit.fluxcd.io/github-status: enabled
+  - target:
+      kind: Kustomization
+      name: flux
+    patch: |-
+      - op: remove
+        path: /metadata/labels/notification.toolkit.fluxcd.io~1github-status


### PR DESCRIPTION
## Summary

- label Kustomizations whose reconciliation should publish commit statuses to `Brocklobsta/cluster`
- scope the GitHub status Alert with `eventSources[].matchLabels`
- explicitly remove the label from `Kustomization/flux`, which is sourced from the upstream `fluxcd/flux2` OCI artifact

## Root cause

The GitHub Alert previously selected every Kustomization. `Kustomization/flux` uses `OCIRepository/flux-manifests`, whose OCI metadata identifies upstream Flux commit `6a650dba1b4ae9945185c4bb3cc3f386aaf71b3d`. Notification-controller then attempted to create a status for that upstream SHA in `Brocklobsta/cluster`, and GitHub correctly returned `422 No commit found for SHA`.

## Validation

- [x] `kubectl kustomize clusters/main/kubernetes` rendered successfully
- [x] all 64 `GitRepository/cluster`-backed Kustomizations render with the status label
- [x] the OCI-backed `flux` Kustomization renders without the status label
- [x] no non-Git Kustomizations are selected
- [x] the Alert renders with the matching label selector
- [x] all 65 rendered Kustomizations plus the GitHub Alert and Provider passed server-side dry-run
- [x] `git diff --check` passed
- [x] repository encryption checks passed

## Expected result

GitHub commit status updates continue for Kustomizations sourced from `Brocklobsta/cluster`, while upstream OCI-backed reconciliations are excluded and no longer generate repeated HTTP 422 notification failures.
