### PR TITLE
fix(emby): restore Intel VA-API driver discovery

### DIFF
--- a/clusters/main/kubernetes/apps/emby/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/emby/app/helm-release.yaml
@@ -119,6 +119,8 @@ spec:
         podSpec:
           containers:
             main:
+              env:
+                LIBVA_DRIVERS_PATH: /app/bin/lib/dri
               resources:
                 limits:
                   gpu.intel.com/i915: 1


### PR DESCRIPTION
## Summary

- set `LIBVA_DRIVERS_PATH=/app/bin/lib/dri` for the main Emby container
- restore Intel VA-API/Quick Sync driver discovery after the Emby `4.10.0.18` image moved its bundled VA driver directory
- preserve the existing `gpu.intel.com/i915` allocation

## Root cause

The previous Emby `4.10.0.11` image successfully initialized `/dev/dri/renderD129`. After the workload moved to Emby `4.10.0.18`, hardware detection reported:

```text
Failed to initialize VA /dev/dri/renderD129. Error -1
```

The GPU remained allocated and accessible. The newer image stores its bundled Intel VA driver at `/app/bin/lib/dri`, but that directory was not in libva's driver search path.

Reproducing with the current container showed that `LD_LIBRARY_PATH=/app/bin/lib` alone fails. Adding `LIBVA_DRIVERS_PATH=/app/bin/lib/dri` makes the current `ffdetect` initialize the Intel iHD driver and discover 28 decoder and 10 encoder capabilities.

## Validation

- [x] Emby chart `27.6.4` rendered successfully with the current release values
- [x] rendered `Deployment/emby` contains `LIBVA_DRIVERS_PATH=/app/bin/lib/dri`
- [x] rendered workload retains `gpu.intel.com/i915: 1`
- [x] `HelmRelease/emby` passed Kubernetes server-side dry-run
- [x] application Kustomize rendering passed
- [x] `git diff --check` passed
- [x] repository encryption checks passed

## Expected result

After Flux reconciles the release and replaces the Emby pod, Emby hardware detection should register the Intel iHD VA-API/Quick Sync codecs again instead of falling back to CPU transcoding.
