### PR TITLE
fix(emby): override VA-API startup paths

### DIFF
--- a/clusters/main/kubernetes/apps/emby/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/emby/app/helm-release.yaml
@@ -43,6 +43,31 @@ spec:
         secretKey: ${S3_SECRET_KEY}
         type: s3
         url: ${S3_ENDPOINT}
+    configmap:
+      start-script:
+        enabled: true
+        data:
+          start.sh: |-
+            #!/usr/bin/env bash
+
+            APP_DIR="/app/bin"
+
+            export AMDGPU_IDS="$APP_DIR/share/libdrm/amdgpu.ids"
+            export FONTCONFIG_PATH="$APP_DIR/etc/fonts"
+            export LD_LIBRARY_PATH="$APP_DIR/lib"
+            export OCL_ICD_VENDORS="$APP_DIR/etc/OpenCL/vendors"
+            export PCI_IDS_PATH="$APP_DIR/share/hwdata/pci.ids"
+            export SSL_CERT_FILE="$APP_DIR/etc/ssl/certs/ca-certificates.crt"
+            export LIBVA_DRIVERS_PATH="$APP_DIR/lib/dri"
+
+            exec \
+                /app/bin/system/EmbyServer \
+                    -programdata /config \
+                    -ffdetect /app/bin/bin/ffdetect \
+                    -ffmpeg /app/bin/bin/ffmpeg \
+                    -ffprobe /app/bin/bin/ffprobe \
+                    -restartexitcode 3 \
+                    "$@"
     ingress:
       main:
         enabled: true
@@ -81,6 +106,14 @@ spec:
               trigger:
                 schedule: 20 8 * * *
             type: restic
+      start-script:
+        enabled: true
+        type: configmap
+        objectName: start-script
+        mountPath: /start.sh
+        subPath: start.sh
+        defaultMode: "0555"
+        readOnly: true
       movies:
         enabled: true
         type: nfs
@@ -119,8 +152,6 @@ spec:
         podSpec:
           containers:
             main:
-              env:
-                LIBVA_DRIVERS_PATH: /app/bin/lib/dri
               resources:
                 limits:
                   gpu.intel.com/i915: 1


### PR DESCRIPTION
## Summary

- replace the Emby image's `/start.sh` with a ConfigMap-mounted corrected copy
- correct every stale `/app/bin/extra` reference for the filesystem layout in Emby `4.10.0.18`
- remove the ineffective container environment override from #4887
- preserve the existing startup command, FFmpeg paths, and Intel GPU allocation

## Root cause

The environment variable added in #4887 reached the pod, but the image's `/start.sh` overwrote it immediately before launching Emby. The upstream script still references the obsolete `/app/bin/extra` hierarchy, which does not exist in this image.

The live image filesystem was inspected path-by-path. The replacement script now uses:

| Variable | Correct path |
|---|---|
| `AMDGPU_IDS` | `/app/bin/share/libdrm/amdgpu.ids` |
| `FONTCONFIG_PATH` | `/app/bin/etc/fonts` |
| `LD_LIBRARY_PATH` | `/app/bin/lib` |
| `OCL_ICD_VENDORS` | `/app/bin/etc/OpenCL/vendors` |
| `PCI_IDS_PATH` | `/app/bin/share/hwdata/pci.ids` |
| `SSL_CERT_FILE` | `/app/bin/etc/ssl/certs/ca-certificates.crt` |
| `LIBVA_DRIVERS_PATH` | `/app/bin/lib/dri` |

All seven paths exist in the deployed `4.10.0.18` image. The replacement contains no `/app/bin/extra` references.

## Validation

- [x] verified every environment path against the running Emby `4.10.0.18` filesystem
- [x] verified `EmbyServer`, `ffdetect`, `ffmpeg`, and `ffprobe` executable paths
- [x] Emby chart `27.6.4` rendered successfully with current release values
- [x] rendered `ConfigMap/emby-start-script` contains no `/app/bin/extra` references
- [x] script passed `bash -n`
- [x] rendered Deployment mounts it read-only at `/start.sh` using `subPath: start.sh` and mode `0555`
- [x] existing `gpu.intel.com/i915: 1` allocation remains unchanged
- [x] direct `ffdetect` using the complete corrected environment discovered the Intel iHD driver, 28 decoders, and 10 encoders
- [x] HelmRelease, rendered ConfigMap, and rendered Deployment passed server-side dry-run
- [x] Kustomize rendering and `git diff --check` passed
- [x] repository encryption checks passed

## Expected result

After Flux reconciles and replaces the pod, the container entrypoint will execute the mounted corrected `/start.sh`. Emby's startup hardware detection should load the bundled Intel iHD driver and register VA-API/Quick Sync codecs.
