### PR TITLE
feat(kromgo): migrate configuration to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,20 +5,20 @@
 A GitOps-managed Kubernetes cluster powered by [TrueCharts ClusterTool](https://truecharts.org/clustertool/), [Talos Linux](https://www.talos.dev/), and [Flux CD](https://fluxcd.io/).
 
 
-[![Talos](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.brocklobsta.net%2Ftalos_version&style=for-the-badge&logo=talos&logoColor=white&label=%20&color=blue)](https://www.talos.dev/)&nbsp;&nbsp;
-[![Kubernetes](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.brocklobsta.net%2Fkubernetes_version&style=for-the-badge&logo=kubernetes&logoColor=white&label=%20&color=blue)](https://www.kubernetes.io/)&nbsp;&nbsp;
-[![Flux](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.brocklobsta.net%2Fflux_version&style=for-the-badge&logo=flux&logoColor=white&color=blue&label=%20)](https://fluxcd.io)&nbsp;&nbsp;
+[![Talos](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.brocklobsta.net%2Fbadges%2Ftalos_version%3Fformat%3Dshields&style=for-the-badge&logo=talos&logoColor=white&label=%20&color=blue)](https://www.talos.dev/)&nbsp;&nbsp;
+[![Kubernetes](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.brocklobsta.net%2Fbadges%2Fkubernetes_version%3Fformat%3Dshields&style=for-the-badge&logo=kubernetes&logoColor=white&label=%20&color=blue)](https://www.kubernetes.io/)&nbsp;&nbsp;
+[![Flux](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.brocklobsta.net%2Fbadges%2Fflux_version%3Fformat%3Dshields&style=for-the-badge&logo=flux&logoColor=white&color=blue&label=%20)](https://fluxcd.io)&nbsp;&nbsp;
 
 [![Home-Internet](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus.brocklobsta.net%2Fapi%2Fv1%2Fendpoints%2Fbuddy_ping-(buddy)%2Fhealth%2Fbadge.shields&style=for-the-badge&logo=ubiquiti&logoColor=white&label=Home%20Internet)](https://status.brocklobsta.net)&nbsp;&nbsp;
 [![Alertmanager](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus.brocklobsta.net%2Fapi%2Fv1%2Fendpoints%2Fbuddy_heartbeat-(buddy)%2Fhealth%2Fbadge.shields&style=for-the-badge&logo=prometheus&logoColor=white&label=Alertmanager)](https://status.brocklobsta.net)
 
-[![Age-Days](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.brocklobsta.net%2Fcluster_age_days&style=flat-square&label=Age)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
-[![Uptime-Days](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.brocklobsta.net%2Fcluster_uptime_days&style=flat-square&label=Uptime)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
-[![Node-Count](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.brocklobsta.net%2Fcluster_node_count&style=flat-square&label=Nodes)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
-[![Pod-Count](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.brocklobsta.net%2Fcluster_pod_count&style=flat-square&label=Pods)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
-[![CPU-Usage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.brocklobsta.net%2Fcluster_cpu_usage&style=flat-square&label=CPU)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
-[![Memory-Usage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.brocklobsta.net%2Fcluster_memory_usage&style=flat-square&label=Memory)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
-[![Alerts](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.brocklobsta.net%2Fcluster_alert_count&style=flat-square&label=Alerts)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
+[![Age-Days](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.brocklobsta.net%2Fbadges%2Fcluster_age_days%3Fformat%3Dshields&style=flat-square&label=Age)](https://github.com/home-operations/kromgo)&nbsp;&nbsp;
+[![Uptime-Days](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.brocklobsta.net%2Fbadges%2Fcluster_uptime_days%3Fformat%3Dshields&style=flat-square&label=Uptime)](https://github.com/home-operations/kromgo)&nbsp;&nbsp;
+[![Node-Count](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.brocklobsta.net%2Fbadges%2Fcluster_node_count%3Fformat%3Dshields&style=flat-square&label=Nodes)](https://github.com/home-operations/kromgo)&nbsp;&nbsp;
+[![Pod-Count](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.brocklobsta.net%2Fbadges%2Fcluster_pod_count%3Fformat%3Dshields&style=flat-square&label=Pods)](https://github.com/home-operations/kromgo)&nbsp;&nbsp;
+[![CPU-Usage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.brocklobsta.net%2Fbadges%2Fcluster_cpu_usage%3Fformat%3Dshields&style=flat-square&label=CPU)](https://github.com/home-operations/kromgo)&nbsp;&nbsp;
+[![Memory-Usage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.brocklobsta.net%2Fbadges%2Fcluster_memory_usage%3Fformat%3Dshields&style=flat-square&label=Memory)](https://github.com/home-operations/kromgo)&nbsp;&nbsp;
+[![Alerts](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.brocklobsta.net%2Fbadges%2Fcluster_alert_count%3Fformat%3Dshields&style=flat-square&label=Alerts)](https://github.com/home-operations/kromgo)&nbsp;&nbsp;
 
 </div>
 

--- a/clusters/main/kubernetes/apps/kromgo/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/kromgo/app/helm-release.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: kromgo
-      version: 2.5.0
+      version: 3.4.1
       sourceRef:
         kind: HelmRepository
         name: truecharts
@@ -45,90 +45,76 @@ spec:
               - path: /
                 pathType: Prefix
     kromgo:
-      badge:
-        font: Verdana.ttf  # Relative to /kromgo - Verdana.ttf is available in the container
-        size: 12
-      metrics:
-        - name: talos_version
+      defaults:
+        badge:
+          font: dejavu-sans
+          size: 12
+          style: flat
+      badges:
+        - id: talos_version
           query: label_replace(node_os_info{name="Talos"}, "version_id", "$1", "version_id", "v(.+)")
-          label: version_id
+          valueExpr: labels["version_id"]
           title: Talos
 
-        - name: kubernetes_version
+        - id: kubernetes_version
           query: label_replace(kubernetes_build_info{service="kubernetes"}, "git_version", "$1", "git_version", "v(.+)")
-          label: git_version
+          valueExpr: labels["git_version"]
           title: Kubernetes
 
-        - name: flux_version
+        - id: flux_version
           query: label_replace(gotk_resource_info{exported_namespace="flux-system",name="flux",customresource_kind="Kustomization"}, "revision", "$1", "revision", "v(.+)@sha256:.+")
-          label: revision
+          valueExpr: labels["revision"]
           title: Flux
 
-        - name: truenas_version
+        - id: truenas_version
           query: truenas_info
-          label: version
+          valueExpr: labels["version"]
           title: Truenas
 
-        - name: cluster_node_count
+        - id: cluster_node_count
           query: count(count by (node) (kube_node_status_condition{condition="Ready"}))
-          colors:
-            - { color: "green", min: 0, max: 9999 }
+          valueExpr: humanizeFloat(result)
+          colorExpr: '"green"'
           title: Nodes
 
-        - name: cluster_pod_count
+        - id: cluster_pod_count
           query: sum(kube_pod_status_phase{phase="Running"})
-          colors:
-            - { color: "green", min: 0, max: 9999 }
+          valueExpr: humanizeFloat(result)
+          colorExpr: '"green"'
           title: Pods
 
-        - name: cluster_cpu_usage
+        - id: cluster_cpu_usage
           query: round(avg(instance:node_cpu_utilisation:rate5m{pod!=""}) * 100, 0.1)
-          suffix: "%"
-          colors:
-            - { color: "green", min: 0, max: 35 }
-            - { color: "orange", min: 36, max: 75 }
-            - { color: "red", min: 76, max: 9999 }
+          valueExpr: humanizeFloat(result) + "%"
+          colorExpr: 'result <= 35.0 ? "green" : result <= 75.0 ? "orange" : "red"'
           title: CPU
 
-        - name: cluster_memory_usage
+        - id: cluster_memory_usage
           query: round(sum(node_memory_MemTotal_bytes{pod!=""} - node_memory_MemAvailable_bytes{pod!=""}) / sum(node_memory_MemTotal_bytes{pod!=""}) * 100, 0.1)
-          suffix: "%"
-          colors:
-            - { color: green, min: 0, max: 35 }
-            - { color: orange, min: 36, max: 75 }
-            - { color: red, min: 76, max: 9999 }
+          valueExpr: humanizeFloat(result) + "%"
+          colorExpr: 'result <= 35.0 ? "green" : result <= 75.0 ? "orange" : "red"'
           title: Memory
 
-        - name: cluster_power_usage
+        - id: cluster_power_usage
           query: round(upsHighPrecOutputLoad, 0.1)
-          suffix: "w"
-          colors:
-            - { color: "green", min: 0, max: 400 }
-            - { color: "orange", min: 401, max: 750 }
-            - { color: "red", min: 751, max: 9999 }
+          valueExpr: humanizeFloat(result) + "w"
+          colorExpr: 'result <= 400.0 ? "green" : result <= 750.0 ? "orange" : "red"'
           title: Power
 
-        - name: cluster_age_days
-          query: round((time() - min(kube_node_created) ) / 86400)
-          suffix: "d"
-          colors:
-            - { color: "green", min: 0, max: 180 }
-            - { color: "orange", min: 181, max: 360 }
-            - { color: "red", min: 361, max: 9999 }
+        - id: cluster_age_days
+          query: round((time() - min(kube_node_created)) / 86400)
+          valueExpr: humanizeFloat(result) + "d"
+          colorExpr: 'result <= 180.0 ? "green" : result <= 360.0 ? "orange" : "red"'
           title: Age
 
-        - name: cluster_uptime_days
+        - id: cluster_uptime_days
           query: round(avg(node_time_seconds{pod!=""} - node_boot_time_seconds{pod!=""}) / 86400)
-          suffix: "d"
-          colors:
-            - { color: "green", min: 0, max: 180 }
-            - { color: "orange", min: 181, max: 360 }
-            - { color: "red", min: 361, max: 9999 }
+          valueExpr: humanizeFloat(result) + "d"
+          colorExpr: 'result <= 180.0 ? "green" : result <= 360.0 ? "orange" : "red"'
           title: Uptime
 
-        - name: cluster_alert_count
+        - id: cluster_alert_count
           query: alertmanager_alerts{state="active"} - 1 # Ignore Watchdog
-          colors:
-            - { color: "green", min: 0, max: 0 }
-            - { color: "red", min: 1, max: 9999 }
+          valueExpr: humanizeFloat(result)
+          colorExpr: 'result <= 0.0 ? "green" : "red"'
           title: Alerts


### PR DESCRIPTION
## Summary

- upgrade the TrueCharts Kromgo release from chart `2.5.0` to `3.4.1` (Kromgo `0.15.1`)
- migrate all 11 legacy `metrics` entries to the v3 `badges` schema
- replace legacy `name`, `label`, `suffix`, and `colors` fields with `id`, CEL `valueExpr`, and CEL `colorExpr`
- switch the removed `Verdana.ttf` font reference to Kromgo's embedded `dejavu-sans` font while preserving the configured size and flat style
- preserve metric IDs, PromQL queries, badge titles, displayed units, and threshold colors
- migrate all README badge sources to `/badges/{id}?format=shields` and update repository links to `home-operations/kromgo`

## Migration notes

Kromgo v3 serves migrated badges at `/badges/{id}`. The repository README now uses the v3 shields.io endpoint format, `/badges/{id}?format=shields`.

The TrueCharts 3.4.1 chart also moves to `ghcr.io/home-operations/kromgo:0.15.1`, mounts configuration at `/config/config.yaml`, uses the `KROMGO_*` runtime environment variables, and probes `/healthz` and `/readyz` on the main listener.

## Validation

- [x] pulled and rendered the exact TrueCharts `kromgo` chart `3.4.1`
- [x] Helm values/schema validation passed during rendering
- [x] rendered configuration contains 11 unique v3 badge IDs
- [x] ran the rendered config with the exact Kromgo `0.15.1` binary extracted from the pinned image
- [x] Kromgo compiled every CEL `valueExpr` and `colorExpr` and reached ready state
- [x] queried all 11 PromQL expressions against the live cluster Prometheus API without query errors
- [x] exercised all 11 `/badges/{id}` endpoints against live Prometheus through the v3 binary; every endpoint returned an SVG badge with HTTP 200
- [x] decoded and checked all 10 README Kromgo badge URLs against configured badge IDs
- [x] exercised all 10 README `?format=shields` URLs through Kromgo `0.15.1`; each returned HTTP 200 and valid shields.io schema version 1 JSON
- [x] verified the rendered Deployment uses the pinned `0.15.1` image and `KROMGO_PROMETHEUS_URL`
- [x] HelmRelease and complete rendered chart passed Kubernetes server-side dry-run
- [x] application Kustomize rendering and `git diff --check` passed
- [x] repository encryption checks passed

## Compatibility

The chart requires Kubernetes `>=1.33.0-0`; the live cluster is running Kubernetes `v1.36.2`.
