### PR TITLE
feat(reactive-resume): deploy application

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ General applications remain under [`clusters/main/kubernetes/apps`](clusters/mai
 | Identity and access | Authentik, Vaultwarden |
 | Development and AI | Code Server, Gitea, Ollama |
 | Home and personal | Home Assistant, KitchenOwl, TeslaMate |
-| Productivity | Nextcloud, Proton Mail Bridge |
+| Productivity | Nextcloud, Proton Mail Bridge, Reactive Resume |
 | Dashboards and utilities | Homepage, IT-Tools, Kubernetes Dashboard, Static |
 | External service portals | Proxmox GUI, TrueNAS GUI |
 | Networking helper | Cloudflare DDNS |

--- a/clusters/main/kubernetes/apps/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - nextcloud/ks.yaml
   - ollama/ks.yaml
   - protonmail-bridge/ks.yaml
+  - reactive-resume/ks.yaml
   - proxmox-gui/ks.yaml
   - static/ks.yaml
   - teslamate/ks.yaml

--- a/clusters/main/kubernetes/apps/reactive-resume/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/reactive-resume/app/helm-release.yaml
@@ -1,0 +1,203 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: reactive-resume
+  namespace: reactive-resume
+spec:
+  interval: 15m
+  chart:
+    spec:
+      chart: app-template
+      version: 18.14.4
+      sourceRef:
+        kind: HelmRepository
+        name: truecharts
+        namespace: flux-system
+      interval: 15m
+  timeout: 20m
+  maxHistory: 3
+  driftDetection:
+    mode: warn
+  install:
+    timeout: 30m
+    createNamespace: true
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  valuesFrom:
+    - kind: Secret
+      name: reactive-resume-values
+      valuesKey: values.yaml
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              group: postgresql.cnpg.io
+              version: v1
+              kind: Cluster
+              name: reactive-resume-app-template-cnpg-main
+            patch: |-
+              - op: add
+                path: /spec/affinity
+                value:
+                  podAntiAffinityType: required
+                  topologyKey: kubernetes.io/hostname
+  values:
+    global:
+      stopAll: false
+    TZ: America/Los_Angeles
+    image:
+      repository: ghcr.io/amruthpillai/reactive-resume
+      tag: v5.2.3@sha256:bfacee69faad04a8b785854d02cb078fb223824e8b07a07ff21fa39ebfa9fe8c
+      pullPolicy: IfNotPresent
+    securityContext:
+      container:
+        runAsUser: 1000
+        runAsGroup: 1000
+        readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        privileged: false
+        seccompProfile:
+          type: RuntimeDefault
+        capabilities:
+          drop:
+            - ALL
+      pod:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 2Gi
+    credentials:
+      b2:
+        accessKey: ${S3_KEY_ID}
+        bucket: ${S3_BUCKET}
+        encrKey: ${S3_PASSWORD}
+        secretKey: ${S3_SECRET_KEY}
+        type: s3
+        url: ${S3_ENDPOINT}
+    workload:
+      main:
+        podSpec:
+          containers:
+            main:
+              env:
+                APP_URL: https://rr.${DOMAIN_0}
+                AUTH_SECRET: '{{ .Values.authSecret }}'
+                DATABASE_URL: '{{ .Values.cnpg.main.creds.std }}'
+                ENCRYPTION_SECRET: '{{ .Values.encryptionSecret }}'
+                FLAG_ALLOW_UNSAFE_AI_BASE_URL: "false"
+                FLAG_ALLOW_UNSAFE_OAUTH_REDIRECT_URI: "false"
+                FLAG_DISABLE_API_RATE_LIMIT: "false"
+                FLAG_DISABLE_EMAIL_AUTH: "false"
+                FLAG_DISABLE_IMAGE_PROCESSING: "false"
+                FLAG_DISABLE_SIGNUPS: "false"
+                FLAG_SHOW_SPONSORS: "false"
+                LOCAL_STORAGE_PATH: /app/data
+                PORT: "3000"
+                REDIS_URL: 'redis://:{{ .Values.redis.password }}@reactive-resume-redis:6379/0'
+              probes:
+                liveness:
+                  enabled: true
+                  type: http
+                  port: 3000
+                  path: /api/health
+                readiness:
+                  enabled: true
+                  type: http
+                  port: 3000
+                  path: /api/health
+                startup:
+                  enabled: true
+                  type: http
+                  port: 3000
+                  path: /api/health
+    service:
+      main:
+        ports:
+          main:
+            port: 3000
+            targetPort: 3000
+            protocol: http
+    ingress:
+      main:
+        enabled: true
+        required: true
+        ingressClassName: external
+        hosts:
+          - host: rr.${DOMAIN_0}
+            paths:
+              - path: /
+                pathType: Prefix
+        integrations:
+          certManager:
+            enabled: true
+            certificateIssuer: domain-0-le-prod
+          nginx:
+            enabled: true
+            auth:
+              type: authentik
+              internalHost: authentik-http.authentik.svc.cluster.local:10230
+              externalHost: auth.${DOMAIN_0}
+              responseHeaders: []
+    persistence:
+      data:
+        enabled: true
+        type: pvc
+        size: 5Gi
+        mountPath: /app/data
+        targetSelectAll: true
+        volsync:
+          - name: data
+            type: restic
+            credentials: b2
+            dest:
+              enabled: true
+            src:
+              enabled: true
+              trigger:
+                schedule: 30 2 * * *
+    cnpg:
+      main:
+        enabled: true
+        mode: standalone
+        database: reactive_resume
+        user: reactive_resume
+        password: ${CNPG_PASSWORD}
+        pgVersion: 16
+        cluster:
+          instances: 2
+          storage:
+            size: 10Gi
+          walStorage:
+            size: 5Gi
+        monitoring:
+          enablePodMonitor: true
+        backups:
+          enabled: true
+          credentials: b2
+          target: prefer-standby
+          scheduledBackups:
+            - name: daily-backup
+              schedule: "0 5 0 * * *"
+              backupOwnerReference: self
+              immediate: true
+              suspend: false
+          retentionPolicy: 30d
+    redis:
+      enabled: true
+      securityContext:
+        container:
+          runAsNonRoot: true
+          runAsUser: 568
+          runAsGroup: 568

--- a/clusters/main/kubernetes/apps/reactive-resume/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/reactive-resume/app/helm-release.yaml
@@ -47,8 +47,12 @@ spec:
               - op: add
                 path: /spec/affinity
                 value:
+                  enablePodAntiAffinity: true
                   podAntiAffinityType: required
                   topologyKey: kubernetes.io/hostname
+              - op: replace
+                path: /spec/enableSuperuserAccess
+                value: false
   values:
     global:
       stopAll: false
@@ -106,6 +110,12 @@ spec:
                 LOCAL_STORAGE_PATH: /app/data
                 PORT: "3000"
                 REDIS_URL: 'redis://:{{ .Values.redis.password }}@reactive-resume-redis:6379/0'
+                SMTP_FROM: "Reactive Resume <${PROTONMAIL_EMAIL}>"
+                SMTP_HOST: protonmail-bridge.protonmail-bridge.svc.cluster.local
+                SMTP_PASS: "${PROTONMAIL_PASSWORD}"
+                SMTP_PORT: "25"
+                SMTP_SECURE: "false"
+                SMTP_USER: "${PROTONMAIL_EMAIL}"
               probes:
                 liveness:
                   enabled: true
@@ -196,6 +206,34 @@ spec:
           retentionPolicy: 30d
     redis:
       enabled: true
+      credentials:
+        b2:
+          type: s3
+          url: "${S3_ENDPOINT}"
+          bucket: "${S3_BUCKET}"
+          accessKey: "${S3_KEY_ID}"
+          secretKey: "${S3_SECRET_KEY}"
+          encrKey: "${S3_PASSWORD}"
+      persistence:
+        data:
+          enabled: true
+          type: pvc
+          storageClass: longhorn
+          accessModes:
+            - ReadWriteOnce
+          size: 2Gi
+          mountPath: /bitnami/valkey
+          targetSelectAll: true
+          volsync:
+            - name: data
+              type: restic
+              credentials: b2
+              dest:
+                enabled: true
+              src:
+                enabled: true
+                trigger:
+                  schedule: "45 2 * * *"
       securityContext:
         container:
           runAsNonRoot: true

--- a/clusters/main/kubernetes/apps/reactive-resume/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/reactive-resume/app/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - values.secret.yaml
+  - helm-release.yaml
+components:
+  - ../../../../components/notifications/discord

--- a/clusters/main/kubernetes/apps/reactive-resume/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/reactive-resume/app/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: reactive-resume
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest

--- a/clusters/main/kubernetes/apps/reactive-resume/app/values.secret.yaml
+++ b/clusters/main/kubernetes/apps/reactive-resume/app/values.secret.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: reactive-resume-values
+    namespace: reactive-resume
+stringData:
+    values.yaml: ENC[AES256_GCM,data:WN839j7Srac2paHPmLYGQ8A1yrJLT58dOCTn0fAYXohMOd5s/tC1a0pijGXuByURI8SzYgY4o0yopGIpFhXxRzAngYDQ3++/m2IwFvDai2I+VeFv5uh42hGNusOr/YWjXQL4ipSG2v9pzJylPSFD/4h87GvQzSmycrc5DZbzO85OR562oLrlEd14rhgu65o5NoNaNptikB+N+4xe+j1MnDxJcIFWLsvb5tZBK5bTykDJJffUc4Q0ecZFtXYcI//zaRlEh3ey6edA+1miO6MEDKc/LVNVGYtLqZg8e7ULKXFD/395RZ05bTaoATynaEg+U/VHN0BwQjUA,iv:KcStoHgJXyEsBK1710msxRy2vhXLjbd+2XFctds7wtM=,tag:pPbQO/YL8iKEQk1Xb73s+w==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvaXYzRHRWWkZxYlMwQU1P
+            MlZkSDJDSzM3bVpDOVJRQUJQUFQ3VjNVYmlzCnVHNm5oc3FYSk1icjhzZEpOalE4
+            ZTIzQXhWcVNQVnVDd3k2dWVqK3lML0EKLS0tIHhTL3JJOHhxdjAveEVLL2I0MzJJ
+            V2VENVJqSlR5bmlXR3Rya1MvWDNSeTQKNiIkHSxmDza8SB/PjeD21KHnzEAmkuw7
+            RZan4vEFowt6sEb7Y/qdh37pgp4yvK3WqFtEsTVvDRNn1RkM/dYg+g==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1xr3zztpafgxmfj0lmwy60su76kwvxgpqdreyax0u2aa99qaftpvsfggls6
+    encrypted_regex: ((?i)(displayname|email|pass|ca|id|bootstraptoken|secretboxencryptionsecret|secrets|secrets|password|cert|secret($|[^N])|key|token|^data$|^stringData))
+    lastmodified: "2026-07-17T20:29:52Z"
+    mac: ENC[AES256_GCM,data:CoVwpSeIPsBHY+DDc1VZ2yhpMPVdKOxz1jzMmvgFR0dFHb19Bj9m85WgXDciOwzYxcuqLTIhK/h+3XrwxKportSuH3xarj4y1USSY4nc+ttO9gFKT5dyxkQpYF9USAJm3HRccDjn/6L+db801RjTK/Dgzk90sKWiKngUoKf8RbE=,iv:Tl/9DppBcx6cdNwhwTn+EntvlFXRSWINv/M/z9pNdFE=,tag:p0DMM/duUwEWN3nh8W1t9w==,type:str]
+    version: 3.13.2

--- a/clusters/main/kubernetes/apps/reactive-resume/app/values.secret.yaml
+++ b/clusters/main/kubernetes/apps/reactive-resume/app/values.secret.yaml
@@ -4,7 +4,7 @@ metadata:
     name: reactive-resume-values
     namespace: reactive-resume
 stringData:
-    values.yaml: ENC[AES256_GCM,data:WN839j7Srac2paHPmLYGQ8A1yrJLT58dOCTn0fAYXohMOd5s/tC1a0pijGXuByURI8SzYgY4o0yopGIpFhXxRzAngYDQ3++/m2IwFvDai2I+VeFv5uh42hGNusOr/YWjXQL4ipSG2v9pzJylPSFD/4h87GvQzSmycrc5DZbzO85OR562oLrlEd14rhgu65o5NoNaNptikB+N+4xe+j1MnDxJcIFWLsvb5tZBK5bTykDJJffUc4Q0ecZFtXYcI//zaRlEh3ey6edA+1miO6MEDKc/LVNVGYtLqZg8e7ULKXFD/395RZ05bTaoATynaEg+U/VHN0BwQjUA,iv:KcStoHgJXyEsBK1710msxRy2vhXLjbd+2XFctds7wtM=,tag:pPbQO/YL8iKEQk1Xb73s+w==,type:str]
+    values.yaml: ENC[AES256_GCM,data:evtBBr1Fi+4DHjozwq00atZD9208SxsTq36GwAcyCkr3+FxKGS4i4tQcU3FaricbOEllGNG3u4MM0hLwnJy7x5wujNOtpxqw368Mmc55SJFeFPw8fOinFntg1a610wN5dSjD1pLbF69s+TNxx9UVvUBasWIaGw0rCbj5a2uGRfSoGUt776qhfGyHDstdr74UqDfEyS9qlo7C1D3S8s42UEJ4NIqqV5oGbJaSH7FagNs7o13zapdxjnZy4/uh5gcxhkrbWpRzUVLxLFPjTM/qns+Izlx+M5Pu9nlI/0djQ+Qzd9fiYS5rmNLcZZwwNswWjB3hSg3bpSqN,iv:QNN7c8u9cnVcYrB5/LH1s7gicpAYMCQ0uuXoJ4Ko5/k=,tag:qdUpJVltZ7QDVRbcYgIFbg==,type:str]
 sops:
     age:
         - enc: |
@@ -17,6 +17,6 @@ sops:
             -----END AGE ENCRYPTED FILE-----
           recipient: age1xr3zztpafgxmfj0lmwy60su76kwvxgpqdreyax0u2aa99qaftpvsfggls6
     encrypted_regex: ((?i)(displayname|email|pass|ca|id|bootstraptoken|secretboxencryptionsecret|secrets|secrets|password|cert|secret($|[^N])|key|token|^data$|^stringData))
-    lastmodified: "2026-07-17T20:29:52Z"
-    mac: ENC[AES256_GCM,data:CoVwpSeIPsBHY+DDc1VZ2yhpMPVdKOxz1jzMmvgFR0dFHb19Bj9m85WgXDciOwzYxcuqLTIhK/h+3XrwxKportSuH3xarj4y1USSY4nc+ttO9gFKT5dyxkQpYF9USAJm3HRccDjn/6L+db801RjTK/Dgzk90sKWiKngUoKf8RbE=,iv:Tl/9DppBcx6cdNwhwTn+EntvlFXRSWINv/M/z9pNdFE=,tag:p0DMM/duUwEWN3nh8W1t9w==,type:str]
+    lastmodified: "2026-07-17T20:44:59Z"
+    mac: ENC[AES256_GCM,data:caMG1Vocbk+06X0VyCY3G5QW+r10OifDRHjrSspd6ESGGG10tQcoZnoHgI1jLdOHfPBNwNghfkY6epCLsU5VzxRLWicnIm1U5HUxuZqhos7i8jQv7DcoDzlvSUJgxJZjli/gj7m99ROWLD0rpd7GWOEoUXxBZ/d1cQGXF3dNGc0=,iv:ZzPs8lnH10t6hcHLTINJXxh77JqInN2qfNFYvZG7i3I=,tag:8X9rmLBQJTQjDEjtH39zhg==,type:str]
     version: 3.13.2

--- a/clusters/main/kubernetes/apps/reactive-resume/ks.yaml
+++ b/clusters/main/kubernetes/apps/reactive-resume/ks.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: reactive-resume
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: cloudnative-pg
+    - name: volsync
+  interval: 10m
+  path: clusters/main/kubernetes/apps/reactive-resume/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: cluster


### PR DESCRIPTION
## Summary

- deploy Reactive Resume `v5.2.3` with the TrueCharts `app-template` chart
- expose it through the external ingress at `rr.brocklobsta.net`
- protect the ingress with the existing Authentik NGINX forward-auth integration
- provide PostgreSQL through a two-instance CloudNativePG cluster and persistent Valkey for the AI workspace
- persist local uploads on Longhorn with VolSync backups and back up PostgreSQL to the existing S3 target
- route account emails through the existing Proton Mail Bridge
- keep application, encryption, and Valkey credentials in a SOPS-encrypted Helm values Secret
- document Reactive Resume in the applications inventory

## Operational details

- Reactive Resume image is pinned to the `v5.2.3` multi-architecture digest.
- The namespace enforces the Kubernetes `restricted` Pod Security profile.
- CNPG instances use required hostname anti-affinity so the primary and replica cannot land on the same node.
- CNPG superuser access is disabled; Reactive Resume uses only its dedicated database role.
- Valkey data is stored on a dedicated Longhorn PVC and protected with VolSync.
- New signups remain enabled behind Authentik so the initial Reactive Resume account can be created.
- The app uses local object storage at `/app/data`; Reactive Resume v5.2.3 performs PDF generation client-side and does not require Browserless.

## Validation

- [x] TrueCharts `app-template` 18.14.4 rendered successfully with Kubernetes 1.36.2 capabilities
- [x] all 20 rendered resources passed live server-side Kubernetes validation
- [x] HelmRelease, Secret, and Flux Kustomization resources passed live server-side validation
- [x] rendered ingress uses `external`, `rr.brocklobsta.net`, the production issuer, and Authentik forward-auth annotations
- [x] rendered CNPG cluster has two instances, required hostname anti-affinity, disabled superuser access, monitoring, daily S3 backups, and 30-day retention
- [x] rendered Valkey StatefulSet mounts its 2 GiB Longhorn PVC and has VolSync source/destination resources
- [x] Proton Mail Bridge has a ready SMTP endpoint and the app receives all required SMTP settings
- [x] rendered application and Valkey security contexts satisfy the namespace's restricted Pod Security policy
- [x] SOPS encryption, generated database/Valkey URLs, Kustomize root rendering, and staged secret scanning passed
- [x] live disposable smoke deployment reached `/api/health` with healthy database and local-storage checks under the application's production security context
- [x] smoke-test namespace and resources were removed after validation
- [x] no existing namespace, Flux Kustomization, or ingress host conflicts with the deployment