### PR TITLE
docs(readme): make memory badge green below 60%

### DIFF
--- a/clusters/main/kubernetes/observability/kromgo/app/helm-release.yaml
+++ b/clusters/main/kubernetes/observability/kromgo/app/helm-release.yaml
@@ -92,7 +92,7 @@ spec:
         - id: cluster_memory_usage
           query: round(sum(node_memory_MemTotal_bytes{pod!=""} - node_memory_MemAvailable_bytes{pod!=""}) / sum(node_memory_MemTotal_bytes{pod!=""}) * 100, 0.1)
           valueExpr: humanizeFloat(result) + "%"
-          colorExpr: 'result <= 35.0 ? "green" : result <= 75.0 ? "orange" : "red"'
+          colorExpr: 'result < 60.0 ? "green" : result <= 75.0 ? "orange" : "red"'
           title: Memory
 
         - id: cluster_power_usage


### PR DESCRIPTION
## Summary

- change the README memory badge's Kromgo color threshold from 35% to 60%
- keep memory usage from 60% through 75% orange and usage above 75% red

The README itself already consumes Kromgo's Shields endpoint, so the threshold is controlled by the `cluster_memory_usage` badge definition rather than by the Markdown image URL.

## Validation

- [x] rendered TrueCharts Kromgo 3.4.1 successfully
- [x] server-side validated all four rendered Kubernetes resources
- [x] started the pinned Kromgo 0.15.1 binary against a mock Prometheus response
- [x] confirmed a 59.9% memory value returns `color: green`
- [x] `git diff --check` passes
