### PR TITLE
fix(longhorn): repair missing storage network attachment

### DIFF
--- a/clusters/main/kubernetes/system/longhorn/app/jobs/kustomization.yaml
+++ b/clusters/main/kubernetes/system/longhorn/app/jobs/kustomization.yaml
@@ -4,3 +4,11 @@ resources:
   - trim.yaml
   - snapshot-delete.yaml
   - snapshot-cleanup.yaml
+  - storage-network-repair.yaml
+  - storage-network-repair-policy.yaml
+
+configMapGenerator:
+  - name: longhorn-storage-network-repair-script
+    namespace: longhorn-system
+    files:
+      - repair.sh=storage-network-repair.sh

--- a/clusters/main/kubernetes/system/longhorn/app/jobs/storage-network-repair-policy.yaml
+++ b/clusters/main/kubernetes/system/longhorn/app/jobs/storage-network-repair-policy.yaml
@@ -1,0 +1,38 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: longhorn-storage-network-repair
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - DELETE
+        resources:
+          - pods
+        scope: Namespaced
+  matchConditions:
+    - name: repair-service-account
+      expression: >-
+        request.userInfo.username ==
+        'system:serviceaccount:longhorn-system:longhorn-storage-network-repair'
+  validations:
+    - expression: >-
+        oldObject.metadata.namespace == 'longhorn-system' &&
+        oldObject.metadata.labels['longhorn.io/component'] == 'instance-manager' &&
+        oldObject.metadata.labels['longhorn.io/data-engine'] == 'v1' &&
+        oldObject.metadata.labels['longhorn.io/managed-by'] == 'longhorn-manager'
+      message: The Longhorn storage-network repair account may delete only v1 instance-manager pods.
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: longhorn-storage-network-repair
+spec:
+  policyName: longhorn-storage-network-repair
+  validationActions:
+    - Deny

--- a/clusters/main/kubernetes/system/longhorn/app/jobs/storage-network-repair.sh
+++ b/clusters/main/kubernetes/system/longhorn/app/jobs/storage-network-repair.sh
@@ -1,0 +1,250 @@
+#!/bin/sh
+set -eu
+
+longhorn_namespace="longhorn-system"
+multus_namespace="kube-system"
+expected_network="longhorn-system/storage-network"
+expected_network_namespace="longhorn-system"
+expected_network_name="storage-network"
+expected_interface="lhnet1"
+instance_manager_selector="longhorn.io/component=instance-manager,longhorn.io/data-engine=v1,longhorn.io/managed-by=longhorn-manager"
+multus_selector="app.kubernetes.io/instance=multus-cni,app.kubernetes.io/name=multus-cni"
+service_account_dir="${SERVICE_ACCOUNT_DIR:-/var/run/secrets/kubernetes.io/serviceaccount}"
+
+pod_is_candidate() {
+  printf '%s' "$1" | jq -e \
+    --arg network_namespace "${expected_network_namespace}" \
+    --arg network_name "${expected_network_name}" \
+    --arg interface "${expected_interface}" '
+      (.metadata.deletionTimestamp == null) and
+      (.status.phase == "Running") and
+      (any(.status.conditions[]?; .type == "Ready" and .status == "True")) and
+      ((now - (.metadata.creationTimestamp | fromdateiso8601)) >= 300) and
+      ((.metadata.annotations["k8s.v1.cni.cncf.io/networks"] // "[]" | fromjson) |
+        any(.[];
+          .namespace == $network_namespace and
+          .name == $network_name and
+          .interface == $interface
+        ))
+    ' >/dev/null
+}
+
+pod_has_storage_network() {
+  printf '%s' "$1" | jq -e \
+    --arg network "${expected_network}" \
+    --arg interface "${expected_interface}" '
+      ((.metadata.annotations["k8s.v1.cni.cncf.io/network-status"] // "[]" | fromjson) |
+        any(.[]; .name == $network and .interface == $interface))
+    ' >/dev/null
+}
+
+multus_is_stable() {
+  node="$1"
+  multus_json=$(kubectl --namespace "${multus_namespace}" get pods \
+    --selector "${multus_selector}" --field-selector "spec.nodeName=${node}" \
+    --output json) || return 2
+  printf '%s' "${multus_json}" | jq -e '
+    any(.items[];
+      .metadata.deletionTimestamp == null and
+      .status.phase == "Running" and
+      (([.status.containerStatuses[]?] | length) > 0) and
+      all(.status.containerStatuses[]?; .ready == true) and
+      (([.status.initContainerStatuses[]?] | length) > 0) and
+      all(.status.initContainerStatuses[]?;
+        .state.terminated.exitCode == 0) and
+      (any(.status.conditions[]?;
+        .type == "Ready" and
+        .status == "True" and
+        ((now - (.lastTransitionTime | fromdateiso8601)) >= 120)
+      ))
+    )
+  ' >/dev/null
+}
+
+volumes_are_healthy() {
+  volumes_json=$(kubectl --namespace "${longhorn_namespace}" get volumes.longhorn.io --output json) || return 2
+  printf '%s' "${volumes_json}" | jq -e '
+    all(.items[];
+      (.status.state == "detached") or
+      (.status.state == "attached" and .status.robustness == "healthy")
+    )
+  ' >/dev/null
+}
+
+setting_json=$(kubectl --namespace "${longhorn_namespace}" get settings.longhorn.io storage-network --output json)
+printf '%s' "${setting_json}" | jq -e \
+  --arg network "${expected_network}" \
+  '.value == $network and .status.applied == true' >/dev/null || {
+    echo "Longhorn storage-network setting is not applied as ${expected_network}" >&2
+    exit 1
+  }
+kubectl --namespace "${longhorn_namespace}" get network-attachment-definition storage-network >/dev/null
+
+for resource in $(kubectl --namespace "${longhorn_namespace}" get pods \
+  --selector "${instance_manager_selector}" --output name); do
+  pod="${resource#pod/}"
+  candidate_json=$(kubectl --namespace "${longhorn_namespace}" get pod "${pod}" --output json)
+
+  if pod_is_candidate "${candidate_json}"; then
+    :
+  else
+    rc=$?
+    [ "${rc}" -eq 1 ] && continue
+    echo "Unable to parse candidate state for ${pod}" >&2
+    exit "${rc}"
+  fi
+
+  if pod_has_storage_network "${candidate_json}"; then
+    continue
+  else
+    rc=$?
+    if [ "${rc}" -ne 1 ]; then
+      echo "Unable to parse network-status for ${pod}" >&2
+      exit "${rc}"
+    fi
+  fi
+
+  node=$(printf '%s' "${candidate_json}" | jq -er '.spec.nodeName')
+  owner=$(printf '%s' "${candidate_json}" | jq -er '
+    .metadata.ownerReferences[] |
+    select(.controller == true and .kind == "InstanceManager") |
+    .name
+  ')
+  instance_manager_json=$(kubectl --namespace "${longhorn_namespace}" get \
+    instancemanagers.longhorn.io "${owner}" --output json)
+  printf '%s' "${instance_manager_json}" | jq -e --arg node "${node}" '
+    .spec.nodeID == $node and .status.currentState == "running"
+  ' >/dev/null || {
+    echo "Skipping ${pod}: owning InstanceManager is not running on ${node}"
+    continue
+  }
+
+  if multus_is_stable "${node}"; then
+    :
+  else
+    rc=$?
+    [ "${rc}" -eq 1 ] && echo "Skipping ${pod}: Multus is not stably Ready on ${node}" && continue
+    exit "${rc}"
+  fi
+  if volumes_are_healthy; then
+    :
+  else
+    rc=$?
+    [ "${rc}" -eq 1 ] && echo "Skipping ${pod}: Longhorn volumes are not in safe states" && continue
+    exit "${rc}"
+  fi
+
+  echo "Safety sample passed for ${pod}; rechecking in 30 seconds"
+  sleep 30
+
+  final_json=$(kubectl --namespace "${longhorn_namespace}" get pod "${pod}" --output json)
+  old_uid=$(printf '%s' "${candidate_json}" | jq -er '.metadata.uid')
+  final_uid=$(printf '%s' "${final_json}" | jq -er '.metadata.uid')
+  if [ "${final_uid}" != "${old_uid}" ]; then
+    echo "Skipping ${pod}: candidate UID changed before deletion"
+    continue
+  fi
+  if pod_is_candidate "${final_json}"; then
+    :
+  else
+    rc=$?
+    [ "${rc}" -eq 1 ] && echo "Skipping ${pod}: candidate is no longer eligible" && continue
+    exit "${rc}"
+  fi
+  if pod_has_storage_network "${final_json}"; then
+    echo "Skipping ${pod}: storage network appeared before deletion"
+    continue
+  else
+    rc=$?
+    if [ "${rc}" -ne 1 ]; then
+      echo "Unable to parse final network-status for ${pod}" >&2
+      exit "${rc}"
+    fi
+  fi
+  final_setting_json=$(kubectl --namespace "${longhorn_namespace}" get \
+    settings.longhorn.io storage-network --output json)
+  printf '%s' "${final_setting_json}" | jq -e --arg network "${expected_network}" '
+    .value == $network and .status.applied == true
+  ' >/dev/null || {
+    echo "Storage-network setting changed before deletion" >&2
+    exit 1
+  }
+  kubectl --namespace "${longhorn_namespace}" get \
+    network-attachment-definition storage-network >/dev/null
+  final_instance_manager_json=$(kubectl --namespace "${longhorn_namespace}" get \
+    instancemanagers.longhorn.io "${owner}" --output json)
+  if ! printf '%s' "${final_instance_manager_json}" | jq -e --arg node "${node}" '
+    .spec.nodeID == $node and .status.currentState == "running"
+  ' >/dev/null; then
+    echo "Skipping ${pod}: owning InstanceManager changed before deletion"
+    continue
+  fi
+  if multus_is_stable "${node}"; then
+    :
+  else
+    rc=$?
+    [ "${rc}" -eq 1 ] && echo "Skipping ${pod}: Multus readiness changed before deletion" && continue
+    exit "${rc}"
+  fi
+  if volumes_are_healthy; then
+    :
+  else
+    rc=$?
+    [ "${rc}" -eq 1 ] && echo "Skipping ${pod}: volume health changed before deletion" && continue
+    exit "${rc}"
+  fi
+
+  delete_body=$(jq -cn --arg uid "${old_uid}" '
+    {apiVersion: "v1", kind: "DeleteOptions", preconditions: {uid: $uid}}
+  ')
+  token=$(cat "${service_account_dir}/token")
+  api_server="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT_HTTPS:-443}"
+  response_file="/tmp/delete-response.json"
+  http_code=$(curl --silent --show-error \
+    --cacert "${service_account_dir}/ca.crt" \
+    --oauth2-bearer "${token}" \
+    --header "Content-Type: application/json" \
+    --request DELETE \
+    --data "${delete_body}" \
+    --output "${response_file}" \
+    --write-out '%{http_code}' \
+    "${api_server}/api/v1/namespaces/${longhorn_namespace}/pods/${pod}")
+  case "${http_code}" in
+    200|202)
+      echo "Recreating ${pod} on ${node}: requested ${expected_network} is missing"
+      ;;
+    409)
+      echo "Skipping ${pod}: UID precondition rejected a stale candidate"
+      exit 0
+      ;;
+    *)
+      echo "Pod deletion failed with HTTP ${http_code}:" >&2
+      cat "${response_file}" >&2
+      exit 1
+      ;;
+  esac
+
+  for attempt in $(seq 1 60); do
+    sleep 5
+    replacement_json=$(kubectl --namespace "${longhorn_namespace}" get pod "${pod}" \
+      --ignore-not-found --output json)
+    [ -n "${replacement_json}" ] || continue
+    new_uid=$(printf '%s' "${replacement_json}" | jq -er '.metadata.uid')
+    [ "${new_uid}" != "${old_uid}" ] || continue
+
+    if pod_has_storage_network "${replacement_json}" && \
+      printf '%s' "${replacement_json}" | jq -e '
+        any(.status.conditions[]?; .type == "Ready" and .status == "True")
+      ' >/dev/null; then
+      echo "${pod} is Ready with ${expected_network}"
+      # Only repair one instance-manager per run to avoid simultaneous disruption.
+      exit 0
+    fi
+    echo "Waiting for replacement ${pod} (${attempt}/60)"
+  done
+
+  echo "Replacement ${pod} did not become Ready with ${expected_network}" >&2
+  exit 1
+done
+
+echo "All Longhorn instance-managers use ${expected_network}"

--- a/clusters/main/kubernetes/system/longhorn/app/jobs/storage-network-repair.yaml
+++ b/clusters/main/kubernetes/system/longhorn/app/jobs/storage-network-repair.yaml
@@ -1,0 +1,157 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: longhorn-storage-network-repair
+  namespace: longhorn-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: longhorn-storage-network-repair
+  namespace: longhorn-system
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - delete
+  - apiGroups:
+      - longhorn.io
+    resources:
+      - volumes
+    verbs:
+      - list
+  - apiGroups:
+      - longhorn.io
+    resources:
+      - instancemanagers
+    verbs:
+      - get
+  - apiGroups:
+      - longhorn.io
+    resources:
+      - settings
+    resourceNames:
+      - storage-network
+    verbs:
+      - get
+  - apiGroups:
+      - k8s.cni.cncf.io
+    resources:
+      - network-attachment-definitions
+    resourceNames:
+      - storage-network
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: longhorn-storage-network-repair
+  namespace: longhorn-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: longhorn-storage-network-repair
+subjects:
+  - kind: ServiceAccount
+    name: longhorn-storage-network-repair
+    namespace: longhorn-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: longhorn-storage-network-repair-multus-reader
+  namespace: kube-system
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: longhorn-storage-network-repair-multus-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: longhorn-storage-network-repair-multus-reader
+subjects:
+  - kind: ServiceAccount
+    name: longhorn-storage-network-repair
+    namespace: longhorn-system
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: longhorn-storage-network-repair
+  namespace: longhorn-system
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 120
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 480
+      backoffLimit: 0
+      ttlSecondsAfterFinished: 900
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: longhorn-storage-network-repair
+        spec:
+          serviceAccountName: longhorn-storage-network-repair
+          automountServiceAccountToken: true
+          enableServiceLinks: false
+          restartPolicy: Never
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: repair
+              image: docker.io/alpine/k8s:1.36.2@sha256:44ef4942e171939b9c665a4a84beb80e2dcdb9a24330d4651cfdfd2e9deecc47
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - /scripts/repair.sh
+              env:
+                - name: HOME
+                  value: /tmp
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 568
+                runAsGroup: 568
+              volumeMounts:
+                - name: script
+                  mountPath: /scripts
+                  readOnly: true
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            - name: script
+              configMap:
+                name: longhorn-storage-network-repair-script
+                defaultMode: 0555
+            - name: tmp
+              emptyDir: {}


### PR DESCRIPTION
## Summary

- add a guarded Longhorn storage-network repair CronJob for instance-manager pods created before Multus is ready after a node reboot
- require exact requested-network/status parsing, stable node-local Multus readiness, two healthy-volume samples, and a running owner CR before remediation
- use a UID-preconditioned API deletion to prevent name-reuse races, repair at most one instance manager per run, and verify its replacement
- enforce deletion scope with a ValidatingAdmissionPolicy, namespace-scoped RBAC, a content-hashed script ConfigMap, and a digest-pinned tool image

## Root cause

During the latest `k8s-control-1` Talos upgrade, its Longhorn instance manager started at `18:13:02Z`, four seconds before the node-local Multus containers started at `18:13:06Z`. The pod requested the storage NAD but never received `k8s.v1.cni.cncf.io/network-status`; Longhorn therefore fell back to its Cilium pod IP. Secondary interfaces cannot be attached to an existing pod retroactively.

## Safety behavior

The repair job fails closed and does nothing unless all of the following are true:

1. The Longhorn storage-network setting is applied as `longhorn-system/storage-network`, and the NAD exists.
2. A v1 Longhorn-managed instance-manager has been Running and Ready for at least five minutes.
3. Its parsed Multus request exactly contains namespace `longhorn-system`, name `storage-network`, and interface `lhnet1`.
4. Its parsed network status lacks the exact `longhorn-system/storage-network` and `lhnet1` tuple.
5. The owning InstanceManager CR is running on the same node.
6. A non-terminating node-local Multus pod has completed its installers, has every container Ready, and has remained Ready for at least two minutes.
7. Two samples thirty seconds apart show every Longhorn volume either detached or attached and healthy.
8. The candidate UID and all safety conditions still match immediately before deletion.

Deletion uses the Kubernetes API with `DeleteOptions.preconditions.uid`. A ValidatingAdmissionPolicy additionally prevents the repair service account from deleting anything except v1 Longhorn-managed instance-manager pods. Only one instance manager is repaired per run, and the job waits for a new UID, exact storage-network attachment, and Pod Ready before succeeding.

Recreating an instance manager is disruptive to engine and replica processes on that node; the global volume-health gate deliberately favors data safety over automatic break-glass remediation.

## Validation

- [x] Longhorn Kustomize tree renders and client-side Kubernetes schema decoding passes
- [x] Jobs Kustomization passes API-server dry-run, including the ValidatingAdmissionPolicy and Binding
- [x] Structural assertions verify exact RBAC, content-hashed script reference, admission guard, security context, immutable image, and fail-closed gates
- [x] Shell syntax passes
- [x] Behavioral harness passes 12 scenarios: already correct, candidate not Ready, candidate too young, split requested-network entries, Multus unavailable, terminating Multus, degraded volume, UID race, similarly prefixed network status, successful repair, malformed status, and API failure
- [x] `alpine/k8s:1.36.2` registry digest verified
- [x] `clustertool checkcrypt` passes
- [x] `git diff --check` passes
- [x] Independent fail-closed security and logic re-review passes with no concerns or suggestions

## Post-merge verification

- confirm Flux reconciles the Longhorn Kustomization and creates the content-hashed script ConfigMap
- observe no remediation while any attached volume is degraded
- after volumes recover, confirm the affected instance-manager is recreated with an `lhnet1` attachment and a `172.30.0.0/24` address
- confirm the InstanceManager CR advertises the storage-network address and Longhorn no longer logs fallback warnings
- confirm subsequent CronJob runs are no-ops
