### PR TITLE
Deploy authenticated Mosquitto broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ General applications remain under [`clusters/main/kubernetes/apps`](clusters/mai
 |---|---|
 | Identity and access | Authentik, Vaultwarden |
 | Development and AI | Code Server, Gitea, Ollama |
-| Home and personal | Home Assistant, TeslaMate |
+| Home and personal | Home Assistant, Mosquitto, TeslaMate |
 | Productivity | Nextcloud, Proton Mail Bridge |
 | Dashboards and utilities | Homepage, IT-Tools, Kubernetes Dashboard, Static |
 | External service portals | Proxmox GUI, TrueNAS GUI |

--- a/clusters/main/kubernetes/apps/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - ollama/ks.yaml
   - protonmail-bridge/ks.yaml
   - proxmox-gui/ks.yaml
+  - smarthome/namespace/ks.yaml
   - static/ks.yaml
   - teslamate/ks.yaml
   - truenas-gui/ks.yaml

--- a/clusters/main/kubernetes/apps/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - homepage/ks.yaml
   - it-tools/ks.yaml
   - kubernetes-dashboard/ks.yaml
+  - mosquitto/ks.yaml
   - nextcloud/ks.yaml
   - ollama/ks.yaml
   - protonmail-bridge/ks.yaml

--- a/clusters/main/kubernetes/apps/mosquitto/app/broker-files.secret.yaml
+++ b/clusters/main/kubernetes/apps/mosquitto/app/broker-files.secret.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: mosquitto-broker-files
+    namespace: mosquitto
+type: Opaque
+data:
+    password_file: ENC[AES256_GCM,data:pQwKpVvI/dB4WFMrYPp2P+KSV1QzJY3LyVYKfwelOInSQ+XqukVNV2T91pO5OguTIAHMSAjZ8rhcvcAteiZevCLyzYJr13foUUAmzAfiY8OmNBWcF/20iXFVA/AJZMvH526hhwhd6r8pF28e8fge572Kfg/ZGwdmxuCTMzMjWvWVk6/FwCxh4O1fRGPwn5iYnuvMJWBocRZLb7Ie2QwQWJcOdLcdVd9cM7bNQ91k16QV0Vpx/abGLptYdsSjIoBXLH+b4O936VuQeDv+83BfNwShJJOi0NMwljb1sbgOb+I+3DZRdEYihQalWDBOGsbDM/mp/GmicIZ20wS+MIptcHEAI9eeLI1EZGqw8fFUouQQ9KIjhEMSEeiJ/snl9s36Y08kQBn2rYlELBUSXiWRe9EwixAVZFDOAcveXsg2CMRwbpjTwdUsLq5EZSJUowUi,iv:PgnEtgy0vKuAZfZU1Zw2INjt5TSbo+HGqtzfUgAEtKo=,tag:aXvxyVL06sHXZFjbpO/ugQ==,type:str]
+    acl_file: ENC[AES256_GCM,data:rFFcRvwk0hmPSYbMRa2cXJWn+5e/7eJxBQ7awT/rHNP6hi6lidqL57yIf4IMhG/Z8iHOceUgezIkg4Xu8pVuI1sqTZiEXE4vin0NEt2VQTMEb3P0hyB5YOO+pqFjQfUWRaeppY1Ig/Of9G6o1OBTkWF9emfKs2sn3RxoTLqisPYu2rwTBPqG4ZgVYCc70YoLg3O8ZnS5EQkxtzNlnAK3c5eDHTpAdxF3Bghg6XngbFphuly2RF76qVrVEf5MHP9O6KhUgdCFIt8GcZOwrei5qVrEp3Xsm4Q2C4j7fcSExYM9CKguAtt3SjOqX763y6zyxl0dcnkUXyc2ekYW2wqSFLTzyA1jo+4NQt+oGRO/qgYFNXM3YoAL7T7vlTjn5WrNkrs4XbbRL6Yx46/aI6QGod22jympa/KuGVBn8KjmE1ArHdvVXIFR2HZMqvxf7C28hs2X7A==,iv:5pzJ3DELmZW9Ck1x3yiQaFaM2PPfqBOgbL4uXLBcYhw=,tag:NEkzOvtGBt01k+SEl5effQ==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBcjlqMTZNQkNhK09iWVZx
+            dzU5UkYvVHFKQ1dPa1llWjhINlVBc0xSdndVClliTzNoZks0MFNXc1Uxc01rSllk
+            SlZCMThaWk0wZk5XVWkySjRqMHVTTTgKLS0tIGRINFVGMU9XaWpQa2pwSGJNMU5D
+            VE5aT09TdStQQ2c5VUZvVU1uMWtxazgKU4z9ZJCvcCG1KtSuVn1TO07XKwIPPekM
+            t9vIx+hTWrp3kZXjxFYjH71jIwyYexzS3KS3kVlp25IBxT/5S7Ik5g==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1xr3zztpafgxmfj0lmwy60su76kwvxgpqdreyax0u2aa99qaftpvsfggls6
+    encrypted_regex: ((?i)(displayname|email|pass|ca|id|bootstraptoken|secretboxencryptionsecret|secrets|secrets|password|cert|secret($|[^N])|key|token|^data$|^stringData))
+    lastmodified: "2026-07-24T20:03:07Z"
+    mac: ENC[AES256_GCM,data:AvTZNraL+b2/fxHSC9z2GTuQtE5HACKZ+Bcl22nTj3kfQdtuMFF0jP+khB1DMi2FhZ+1qj7TyEug3SYfrME2qbvpVabLhTE5/Ou524z2xl/DDbgdfpuTzJfCKveoI0s5ll1sUPw/t6BSHSwnvKAJmBJ+vcKLpAZw0CMo5ILMRbs=,iv:QqORbsWFD6mXAkQLJ265OWbA/+mW5grLCdCRxH3yOYo=,tag:AJxcVzoyYxAe62Gn5egImw==,type:str]
+    version: 3.13.2

--- a/clusters/main/kubernetes/apps/mosquitto/app/broker-files.secret.yaml
+++ b/clusters/main/kubernetes/apps/mosquitto/app/broker-files.secret.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: mosquitto-broker-files
-    namespace: mosquitto
+    namespace: smarthome
 type: Opaque
 data:
     password_file: ENC[AES256_GCM,data:pQwKpVvI/dB4WFMrYPp2P+KSV1QzJY3LyVYKfwelOInSQ+XqukVNV2T91pO5OguTIAHMSAjZ8rhcvcAteiZevCLyzYJr13foUUAmzAfiY8OmNBWcF/20iXFVA/AJZMvH526hhwhd6r8pF28e8fge572Kfg/ZGwdmxuCTMzMjWvWVk6/FwCxh4O1fRGPwn5iYnuvMJWBocRZLb7Ie2QwQWJcOdLcdVd9cM7bNQ91k16QV0Vpx/abGLptYdsSjIoBXLH+b4O936VuQeDv+83BfNwShJJOi0NMwljb1sbgOb+I+3DZRdEYihQalWDBOGsbDM/mp/GmicIZ20wS+MIptcHEAI9eeLI1EZGqw8fFUouQQ9KIjhEMSEeiJ/snl9s36Y08kQBn2rYlELBUSXiWRe9EwixAVZFDOAcveXsg2CMRwbpjTwdUsLq5EZSJUowUi,iv:PgnEtgy0vKuAZfZU1Zw2INjt5TSbo+HGqtzfUgAEtKo=,tag:aXvxyVL06sHXZFjbpO/ugQ==,type:str]
@@ -19,6 +19,6 @@ sops:
             -----END AGE ENCRYPTED FILE-----
           recipient: age1xr3zztpafgxmfj0lmwy60su76kwvxgpqdreyax0u2aa99qaftpvsfggls6
     encrypted_regex: ((?i)(displayname|email|pass|ca|id|bootstraptoken|secretboxencryptionsecret|secrets|secrets|password|cert|secret($|[^N])|key|token|^data$|^stringData))
-    lastmodified: "2026-07-24T20:03:07Z"
-    mac: ENC[AES256_GCM,data:AvTZNraL+b2/fxHSC9z2GTuQtE5HACKZ+Bcl22nTj3kfQdtuMFF0jP+khB1DMi2FhZ+1qj7TyEug3SYfrME2qbvpVabLhTE5/Ou524z2xl/DDbgdfpuTzJfCKveoI0s5ll1sUPw/t6BSHSwnvKAJmBJ+vcKLpAZw0CMo5ILMRbs=,iv:QqORbsWFD6mXAkQLJ265OWbA/+mW5grLCdCRxH3yOYo=,tag:AJxcVzoyYxAe62Gn5egImw==,type:str]
+    lastmodified: "2026-07-24T20:54:38Z"
+    mac: ENC[AES256_GCM,data:iTcYxZ0TjitSBC7zz/SbGkdKtWM4ajfUNNeYR9FTVORihEXBnUYojWySrwlIbwkArsJJcystJrq6zLsjhtI19LItPeHWYMEzC4RT4X1PT0eg1D4l/J/4jhT5VF8kG2k7u76SaN+1HIoRxJGYznJLYcTSbekK75R7HxWix7x7Ay8=,iv:SA9Tn7vddcpfYfhXDHUwRIqm2oNPJ6+BdT8Tg4Uakmw=,tag:fNJoteSovw0Uu0A766AM2g==,type:str]
     version: 3.13.2

--- a/clusters/main/kubernetes/apps/mosquitto/app/client-credentials.secret.yaml
+++ b/clusters/main/kubernetes/apps/mosquitto/app/client-credentials.secret.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: mosquitto-client-credentials
+    namespace: mosquitto
+type: Opaque
+data:
+    homeassistant-password: ENC[AES256_GCM,data:EvhsBX4liBBGvG3bYUsbXDzbHth6Isd6fhU+BbJ7rj1t53EE7PqnvFokeP5uhqKz+t/pmPQc3+cfBQI2,iv:xuenSyNjEK8S8PLkstvYc5TdtrV6UKZHj/LFCKo9mOk=,tag:+w6ox76QyEhOLR9zdi45qQ==,type:str]
+    zigbee2mqtt-password: ENC[AES256_GCM,data:DyiV/TCwltnx1ucXTI9o+c0zes43Cp59bRPs7sraOezWTGL7z8bTMP28AiSiTc/OlTVUh9jOeK1Beeok,iv:Ohe3At15vhShaPAluvuHvUncD+Ipp99/73R27OPSH/o=,tag:y4wSTCoQ0PYPTMO74xT7jQ==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzN05KMFY4WWdOdnBFVVkz
+            ait0UlR4MGpxSWRsMklpVXovcEVBTjFZQVEwCnNVRC9YZHlzN3RLNHhSdmxBeFRT
+            NlFFSXNBL2M0VnpiU00yTTc5d0I1N2sKLS0tIDFsam5jSExySmQ1RjZSL2JqdlQw
+            L0JrUDNwWmdvZXA5UmQzOElsMnBXNkUKInOVzCgUnG2TXGK/NPLpIPr+zqWIwJJb
+            Z3CD4JiL3RmCMx0zGC8IP73JacB4qqy4In44C9qft9s5TyoPqCOtLg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1xr3zztpafgxmfj0lmwy60su76kwvxgpqdreyax0u2aa99qaftpvsfggls6
+    encrypted_regex: ((?i)(displayname|email|pass|ca|id|bootstraptoken|secretboxencryptionsecret|secrets|secrets|password|cert|secret($|[^N])|key|token|^data$|^stringData))
+    lastmodified: "2026-07-24T20:03:07Z"
+    mac: ENC[AES256_GCM,data:scswYR/yF7zoXYe1YaCJtmoUjp69UgMgy85JtRzP3bnPClotrl/TibegFqUo/FjWkosTv9OfLcdtRQBbOhXKnupq5J+AySDn7iruaMzq4HnpIetSnXs9x8oTeVzUCi7vYJmhZGjVdQ/YVT6mYEKu89lmMgzUNi9GipIEtE9qsm0=,iv:hMizmssr7aO18P77bRd6TqvbfZl8hi10kKGtwR+HV2w=,tag:kSvJKmeL0rlDjOL5SSFO6w==,type:str]
+    version: 3.13.2

--- a/clusters/main/kubernetes/apps/mosquitto/app/client-credentials.secret.yaml
+++ b/clusters/main/kubernetes/apps/mosquitto/app/client-credentials.secret.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: mosquitto-client-credentials
-    namespace: mosquitto
+    namespace: smarthome
 type: Opaque
 data:
     homeassistant-password: ENC[AES256_GCM,data:EvhsBX4liBBGvG3bYUsbXDzbHth6Isd6fhU+BbJ7rj1t53EE7PqnvFokeP5uhqKz+t/pmPQc3+cfBQI2,iv:xuenSyNjEK8S8PLkstvYc5TdtrV6UKZHj/LFCKo9mOk=,tag:+w6ox76QyEhOLR9zdi45qQ==,type:str]
@@ -19,6 +19,6 @@ sops:
             -----END AGE ENCRYPTED FILE-----
           recipient: age1xr3zztpafgxmfj0lmwy60su76kwvxgpqdreyax0u2aa99qaftpvsfggls6
     encrypted_regex: ((?i)(displayname|email|pass|ca|id|bootstraptoken|secretboxencryptionsecret|secrets|secrets|password|cert|secret($|[^N])|key|token|^data$|^stringData))
-    lastmodified: "2026-07-24T20:03:07Z"
-    mac: ENC[AES256_GCM,data:scswYR/yF7zoXYe1YaCJtmoUjp69UgMgy85JtRzP3bnPClotrl/TibegFqUo/FjWkosTv9OfLcdtRQBbOhXKnupq5J+AySDn7iruaMzq4HnpIetSnXs9x8oTeVzUCi7vYJmhZGjVdQ/YVT6mYEKu89lmMgzUNi9GipIEtE9qsm0=,iv:hMizmssr7aO18P77bRd6TqvbfZl8hi10kKGtwR+HV2w=,tag:kSvJKmeL0rlDjOL5SSFO6w==,type:str]
+    lastmodified: "2026-07-24T20:54:38Z"
+    mac: ENC[AES256_GCM,data:RqcNrALkt1yHPea3BACD4PGd4jrS/LV1qLY+Q8HF4iGBMyeNYLjaO2Ft3mR+YkUkxapZlq6jz9IDu7it2IspwVr0Jfd+/BDjbsTgY9P2pOY35PuX4ZkfVuGkmaSQPFmDdmuPxVtoWoPR5JyIBSh759V471axxg7+e2Ss3KpHQpY=,iv:0Mstt6VTG3x+WCllyKFXEmUN1CYwwNx+PlSAFGQBYL8=,tag:iv221QgHU4APOQ0l5epjsQ==,type:str]
     version: 3.13.2

--- a/clusters/main/kubernetes/apps/mosquitto/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/mosquitto/app/helm-release.yaml
@@ -1,0 +1,148 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: mosquitto
+  namespace: mosquitto
+spec:
+  interval: 15m
+  chart:
+    spec:
+      chart: mosquitto
+      version: 18.6.0
+      sourceRef:
+        kind: HelmRepository
+        name: truecharts
+        namespace: flux-system
+      interval: 15m
+  timeout: 20m
+  maxHistory: 3
+  driftDetection:
+    mode: warn
+  install:
+    timeout: 30m
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              group: volsync.backube
+              version: v1alpha1
+              kind: ReplicationDestination
+            patch: |-
+              - op: add
+                path: /spec/restic/moverSecurityContext/runAsNonRoot
+                value: true
+              - op: add
+                path: /spec/restic/moverSecurityContext/seccompProfile
+                value:
+                  type: RuntimeDefault
+          - target:
+              group: volsync.backube
+              version: v1alpha1
+              kind: ReplicationSource
+            patch: |-
+              - op: add
+                path: /spec/restic/moverSecurityContext/runAsNonRoot
+                value: true
+              - op: add
+                path: /spec/restic/moverSecurityContext/seccompProfile
+                value:
+                  type: RuntimeDefault
+  values:
+    TZ: America/Los_Angeles
+    auth:
+      enabled: true
+    websockets:
+      enabled: false
+    service:
+      websockets:
+        enabled: false
+    configmap:
+      config:
+        enabled: true
+        data:
+          mosquitto.conf: |
+            listener 1883
+            protocol mqtt
+            allow_anonymous false
+            password_file /mosquitto/secrets/password_file
+            acl_file /mosquitto/secrets/acl_file
+            persistence true
+            persistence_location /mosquitto/data
+            persistence_file mosquitto.db
+            autosave_interval 1800
+            log_dest stdout
+            log_type error
+            log_type warning
+            log_type notice
+            connection_messages true
+    credentials:
+      b2:
+        accessKey: ${S3_KEY_ID}
+        bucket: ${S3_BUCKET}
+        encrKey: ${S3_PASSWORD}
+        name: b2
+        secretKey: ${S3_SECRET_KEY}
+        type: s3
+        url: ${S3_ENDPOINT}
+    persistence:
+      data:
+        enabled: true
+        mountPath: /mosquitto/data
+        size: 1Gi
+        volsync:
+          - credentials: b2
+            dest:
+              enabled: true
+            name: data
+            src:
+              enabled: true
+              trigger:
+                schedule: 35 1 * * *
+            type: restic
+      configinc:
+        enabled: false
+      broker-files:
+        enabled: true
+        type: secret
+        objectName: mosquitto-broker-files
+        expandObjectName: false
+        mountPath: /mosquitto/secrets
+        readOnly: true
+        defaultMode: "0440"
+        items:
+          - key: password_file
+            path: password_file
+          - key: acl_file
+            path: acl_file
+    resources:
+      requests:
+        cpu: 10m
+        memory: 50Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
+    securityContext:
+      container:
+        runAsNonRoot: true
+        runAsUser: 568
+        runAsGroup: 568
+        readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        privileged: false
+        seccompProfile:
+          type: RuntimeDefault
+        capabilities:
+          drop:
+            - ALL
+      pod:
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch

--- a/clusters/main/kubernetes/apps/mosquitto/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/mosquitto/app/helm-release.yaml
@@ -2,7 +2,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: mosquitto
-  namespace: mosquitto
+  namespace: smarthome
 spec:
   interval: 15m
   chart:
@@ -20,7 +20,7 @@ spec:
     mode: warn
   install:
     timeout: 30m
-    createNamespace: true
+    createNamespace: false
     remediation:
       retries: 3
   upgrade:

--- a/clusters/main/kubernetes/apps/mosquitto/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/mosquitto/app/kustomization.yaml
@@ -1,7 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - namespace.yaml
   - broker-files.secret.yaml
   - client-credentials.secret.yaml
   - network-policy.yaml

--- a/clusters/main/kubernetes/apps/mosquitto/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/mosquitto/app/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - broker-files.secret.yaml
+  - client-credentials.secret.yaml
+  - network-policy.yaml
+  - helm-release.yaml

--- a/clusters/main/kubernetes/apps/mosquitto/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/mosquitto/app/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mosquitto
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/clusters/main/kubernetes/apps/mosquitto/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/mosquitto/app/namespace.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: mosquitto
-  labels:
-    pod-security.kubernetes.io/enforce: restricted
-    pod-security.kubernetes.io/audit: restricted
-    pod-security.kubernetes.io/warn: restricted

--- a/clusters/main/kubernetes/apps/mosquitto/app/network-policy.yaml
+++ b/clusters/main/kubernetes/apps/mosquitto/app/network-policy.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: mosquitto
-  namespace: mosquitto
+  namespace: smarthome
 spec:
   podSelector:
     matchLabels:
@@ -11,15 +11,28 @@ spec:
     - Ingress
   ingress:
     - from:
+        # Final-state consumers in the shared smarthome namespace.
+        # Home Assistant currently uses hostNetwork. Cilium treats that source
+        # as node/host traffic, so Kubernetes pod selectors cannot isolate it;
+        # broker authentication and ACLs remain the enforcement boundary.
+        # Keep explicit selectors for intent and for a future non-hostNetwork HA.
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: home-assistant
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: zigbee2mqtt
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: mosquitto
+        # Transitional access until Home Assistant is migrated from its
+        # existing namespace with its PVCs and CloudNativePG cluster.
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: home-assistant
-        - namespaceSelector:
+          podSelector:
             matchLabels:
-              kubernetes.io/metadata.name: zigbee2mqtt
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: mosquitto
+              app.kubernetes.io/instance: home-assistant
       ports:
         - protocol: TCP
           port: 1883

--- a/clusters/main/kubernetes/apps/mosquitto/app/network-policy.yaml
+++ b/clusters/main/kubernetes/apps/mosquitto/app/network-policy.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: mosquitto
+  namespace: mosquitto
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: mosquitto
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: home-assistant
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: zigbee2mqtt
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: mosquitto
+      ports:
+        - protocol: TCP
+          port: 1883

--- a/clusters/main/kubernetes/apps/mosquitto/ks.yaml
+++ b/clusters/main/kubernetes/apps/mosquitto/ks.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: mosquitto
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: clusters/main/kubernetes/apps/mosquitto/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: cluster

--- a/clusters/main/kubernetes/apps/smarthome/namespace/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/smarthome/namespace/app/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml

--- a/clusters/main/kubernetes/apps/smarthome/namespace/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/smarthome/namespace/app/namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: smarthome
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    # Home Assistant requires host networking and direct Zigbee device access.
+    # Each workload still defines the narrowest viable pod/container context.
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/clusters/main/kubernetes/apps/smarthome/namespace/ks.yaml
+++ b/clusters/main/kubernetes/apps/smarthome/namespace/ks.yaml
@@ -1,13 +1,11 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: mosquitto
+  name: smarthome-namespace
   namespace: flux-system
 spec:
   interval: 10m
-  dependsOn:
-    - name: smarthome-namespace
-  path: clusters/main/kubernetes/apps/mosquitto/app
+  path: clusters/main/kubernetes/apps/smarthome/namespace/app
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
## Summary

- deploys the TrueCharts Mosquitto chart into the shared `smarthome` namespace as the MQTT foundation for the ZHA-to-Zigbee2MQTT migration
- establishes `smarthome` as the final namespace for Home Assistant, Mosquitto, and Zigbee2MQTT
- creates `smarthome` through a dedicated Flux Kustomization protected from accidental namespace pruning; Mosquitto depends on that namespace owner
- requires authentication with separate Home Assistant and Zigbee2MQTT users and topic-scoped ACLs
- mounts SOPS-encrypted password/ACL files outside Mosquitto's `include_dir`
- keeps MQTT ClusterIP-only and restricts ordinary pod ingress to expected smart-home workloads
- preserves transitional access from the existing `home-assistant` namespace until its stateful migration is completed
- persists broker state on a 1 GiB Longhorn PVC with B2-backed VolSync protection
- retains explicit restricted security settings on Mosquitto and VolSync movers even though the shared namespace must permit Home Assistant's host-network/device requirements
- updates the application inventory documentation

## Shared-namespace rollout

Mosquitto is created directly in `smarthome`. Home Assistant remains in its current `home-assistant` namespace in this PR because moving its config and Matter PVCs plus its CloudNativePG cluster requires a backup/restore cutover rather than a namespace rename. A follow-up migration will move Home Assistant state into `smarthome`; the transitional NetworkPolicy rule is removed afterward. Zigbee2MQTT will then be staged stopped in the same namespace.

This sequencing avoids creating a fresh Home Assistant instance or pruning the existing stateful namespace before its PVC and database data have been restored and verified.

## Validation

- [x] TrueCharts `mosquitto` 18.6.0 rendered with Helm 3.21.2 and dummy S3 values in `smarthome`
- [x] chart render verified as Mosquitto 2.0.22 with only TCP/1883 exposed
- [x] rendered Deployment uses non-root UID/GID 568, read-only root filesystem, RuntimeDefault seccomp, no privilege escalation, and drops all capabilities
- [x] password and ACL files mount read-only from a dedicated Secret outside `include_dir`
- [x] PVC request rendered as 1 GiB
- [x] VolSync post-renderer produced `runAsNonRoot: true` and RuntimeDefault seccomp on source/destination movers
- [x] app and root Kustomize renders succeeded
- [x] decrypted temporary Secrets, NetworkPolicy, HelmRelease, and fully rendered chart passed server-side dry-run
- [x] ClusterTool encryption checks passed; all committed Secret data remains SOPS encrypted and MAC-valid
- [x] exact Mosquitto 2.0.22 image accepted the generated password hashes
- [x] isolated live smoke tests rejected anonymous and incorrect-password clients
- [x] Home Assistant/Zigbee2MQTT ACL-allowed discovery and command topics delivered successfully
- [x] isolated ACL test proved a Home Assistant write-denied topic was not retained
- [x] live Cilium control test confirmed ordinary pod selectors work but `hostNetwork` sources cannot be isolated by Kubernetes NetworkPolicy; Mosquitto authentication and ACLs therefore remain mandatory for Home Assistant traffic

## Deployment notes

This PR does not alter ZHA, Home Assistant state, or coordinator ownership. After merge, Flux should reconcile Mosquitto in `smarthome` independently while Home Assistant remains on ZHA. Home Assistant MQTT integration setup and live broker verification are post-merge gates before the Home Assistant namespace migration.

Home Assistant currently uses `hostNetwork`. On this cluster, Cilium treats that traffic as node/host traffic, so a Kubernetes NetworkPolicy cannot distinguish the Home Assistant pod from other host-network sources by pod label. The policy still isolates ordinary pods (including Zigbee2MQTT), while broker authentication and topic ACLs provide the required Home Assistant enforcement boundary. Tight host-level isolation would require a separate cluster-wide Cilium host-firewall design and is intentionally outside this focused PR.

## Rollback

Revert this PR. Flux will prune the Mosquitto release; the prune-protected `smarthome` Namespace object may remain empty for safety. No Home Assistant or Zigbee radio state is changed by this PR.
