### PR TITLE
fix(authentik): persist admin sessions for 30 days

### DIFF
--- a/clusters/main/kubernetes/apps/authentik/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/authentik/app/helm-release.yaml
@@ -18,6 +18,32 @@ spec:
   maxHistory: 3
   driftDetection:
     mode: warn
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              group: apps
+              version: v1
+              kind: Deployment
+              name: authentik-worker
+            patch: |-
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: authentik-worker
+              spec:
+                template:
+                  spec:
+                    containers:
+                      - name: authentik
+                        volumeMounts:
+                          - name: session-blueprint
+                            mountPath: /blueprints/custom/managed
+                            readOnly: true
+                    volumes:
+                      - name: session-blueprint
+                        configMap:
+                          name: authentik-session-blueprint
   install:
     timeout: 30m
     createNamespace: true

--- a/clusters/main/kubernetes/apps/authentik/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/authentik/app/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 resources:
   - helm-release.yaml
   - namespace.yaml
+  - session-blueprint.yaml
 components:
   - ../../../../components/notifications/discord

--- a/clusters/main/kubernetes/apps/authentik/app/session-blueprint.yaml
+++ b/clusters/main/kubernetes/apps/authentik/app/session-blueprint.yaml
@@ -1,0 +1,76 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-session-blueprint
+  namespace: authentik
+data:
+  30-day-session.yaml: |-
+    version: 1
+    metadata:
+      name: Admin 30-day authentication session
+    entries:
+      - model: authentik_flows.flow
+        id: admin-authentication-flow
+        identifiers:
+          slug: admin-30-day-authentication
+        attrs:
+          name: Admin 30-day authentication
+          title: Welcome to authentik!
+          designation: authentication
+          authentication: none
+      - model: authentik_stages_user_login.userloginstage
+        id: admin-authentication-login
+        identifiers:
+          name: admin-30-day-authentication-login
+        attrs:
+          session_duration: days=30
+      - model: authentik_flows.flowstagebinding
+        identifiers:
+          target: !KeyOf admin-authentication-flow
+          stage: !Find [authentik_stages_identification.identificationstage, [name, default-authentication-identification]]
+          order: 10
+      - model: authentik_flows.flowstagebinding
+        id: admin-password-binding
+        identifiers:
+          target: !KeyOf admin-authentication-flow
+          stage: !Find [authentik_stages_password.passwordstage, [name, default-authentication-password]]
+          order: 20
+        attrs:
+          re_evaluate_policies: true
+      - model: authentik_flows.flowstagebinding
+        id: admin-mfa-binding
+        identifiers:
+          target: !KeyOf admin-authentication-flow
+          stage: !Find [authentik_stages_authenticator_validate.authenticatorvalidatestage, [name, default-authentication-mfa-validation]]
+          order: 30
+      - model: authentik_flows.flowstagebinding
+        identifiers:
+          target: !KeyOf admin-authentication-flow
+          stage: !KeyOf admin-authentication-login
+          order: 100
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !KeyOf admin-password-binding
+          policy: !Find [authentik_policies_expression.expressionpolicy, [name, default-authentication-flow-password-stage]]
+          order: 10
+        attrs:
+          failure_result: true
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !KeyOf admin-mfa-binding
+          policy: !Find [authentik_policies_expression.expressionpolicy, [name, default-authentication-flow-authenticator-validate-stage]]
+          order: 10
+        attrs:
+          failure_result: true
+      - model: authentik_providers_proxy.proxyprovider
+        state: present
+        identifiers:
+          name: Brocklobsta ForwardAuth
+        attrs:
+          authentication_flow: !KeyOf admin-authentication-flow
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          external_host: https://auth.${DOMAIN_0}
+          mode: forward_domain
+          access_token_validity: days=30
+          refresh_token_validity: days=30


### PR DESCRIPTION
## Summary

- add a Git-managed Authentik blueprint for the `Admin` application’s `Brocklobsta ForwardAuth` provider
- create a dedicated authentication flow that mirrors the existing password and MFA behavior
- set that flow’s login session and the provider’s access/refresh tokens to 30 days
- mount the managed blueprint only into the Authentik worker through a Flux Helm post-render patch

## Why

`Brocklobsta ForwardAuth` already had a 30-day access-token validity, but it used `default-authentication-flow`. That flow ends in `default-authentication-login`, whose `session_duration` is `seconds=0`, so the Authentik session ends with the browser session and results in frequent logins.

The dedicated flow avoids lengthening the shared default authentication flow for unrelated applications.

## Validation

- `kubectl kustomize` rendered the Authentik application
- Kubernetes client-side dry-run passed
- HelmRelease CRD server-side dry-run passed
- ConfigMap server-side dry-run passed
- TrueCharts Authentik 41.1.0 rendered successfully with Helm 3.18.6
- the Flux post-render patch was simulated with Kustomize; only `authentik-worker` received the blueprint mount
- Authentik 2026.5.6 accepted the blueprint with `Importer.validate(raise_validation_errors=True)`
- a transaction-rolled-back apply verified:
  - provider authentication flow changes to `admin-30-day-authentication`
  - login stage duration is `days=30`
  - stage orders remain `10, 20, 30, 100`
  - password and MFA conditional policies are retained
  - no provider fields change except `authentication_flow` against current live state
- `clustertool checkcrypt` passed
- `git diff --check` passed

## Operational impact

The Helm reconciliation rolled the Authentik server, LDAP, and worker deployments; all returned Ready. Only the worker received the blueprint volume. Existing sessions are not extended retroactively; the 30-day lifetime applies after the user signs in again.
