### PR TITLE
fix(longhorn): escape Multus init runtime variable

### DIFF
--- a/clusters/main/kubernetes/system/longhorn/app/instance-manager-multus-init.yaml
+++ b/clusters/main/kubernetes/system/longhorn/app/instance-manager-multus-init.yaml
@@ -43,7 +43,7 @@ spec:
                   imagePullPolicy: "IfNotPresent",
                   command: ["/bin/sh", "-ec"],
                   args: [
-                    "echo \"Waiting for Multus on ${NODE_NAME}\"\nuntil kubectl wait --namespace=kube-system --for=condition=Ready pod --selector=app.kubernetes.io/name=multus-cni --field-selector=spec.nodeName=${NODE_NAME},status.phase=Running --timeout=10s; do\n  echo \"Multus is not ready on ${NODE_NAME}; retrying\"\n  sleep 5\ndone\n"
+                    "echo \"Waiting for Multus on $${NODE_NAME}\"\nuntil kubectl wait --namespace=kube-system --for=condition=Ready pod --selector=app.kubernetes.io/name=multus-cni --field-selector=spec.nodeName=$${NODE_NAME},status.phase=Running --timeout=10s; do\n  echo \"Multus is not ready on $${NODE_NAME}; retrying\"\n  sleep 5\ndone\n"
                   ],
                   env: [
                     Object.spec.initContainers.env{


### PR DESCRIPTION
## Summary

- escape the init container's runtime `${NODE_NAME}` references from Flux post-build substitution
- preserve `${NODE_NAME}` for expansion by `/bin/sh` inside the injected init container

## Root cause

The Longhorn Flux Kustomization enables strict post-build substitution. Flux interpreted the init-container shell references as GitOps variables and rejected the rendered `MutatingAdmissionPolicy` because `NODE_NAME` is intentionally not present in `cluster-config`.

## Validation

- reproduced the failure by detecting the unescaped `${NODE_NAME}` references in the merged manifest
- verified all three runtime references now use Flux's `$${NODE_NAME}` literal escape
- `flux envsubst --strict` passed and emitted exactly three `${NODE_NAME}` runtime shell references
- focused Kubernetes server-side dry-run accepted the Flux-substituted policy and binding
- Longhorn Kustomize rendering passed
- `clustertool checkcrypt` passed
- `git diff --check` passed

No live resources were modified. Once merged, Flux should create the admission policy and binding; existing instance-manager Pods will remain unchanged until Longhorn replaces them.
