### PR TITLE
fix(longhorn): use JSON Patch for Multus init container

### DIFF
--- a/clusters/main/kubernetes/system/longhorn/app/instance-manager-multus-init.yaml
+++ b/clusters/main/kubernetes/system/longhorn/app/instance-manager-multus-init.yaml
@@ -31,41 +31,46 @@ spec:
         !has(object.spec.initContainers) ||
         !object.spec.initContainers.exists(container, container.name == "wait-for-multus")
   mutations:
-    - patchType: ApplyConfiguration
-      applyConfiguration:
+    - patchType: JSONPatch
+      jsonPatch:
         expression: >-
-          Object{
-            spec: Object.spec{
-              initContainers: [
-                Object.spec.initContainers{
-                  name: "wait-for-multus",
-                  image: "docker.io/alpine/kubectl:1.36.2@sha256:9b053116c5c9b746e466230ea3b8bd381757064ee483e236dbadcf7f798f73cf",
-                  imagePullPolicy: "IfNotPresent",
-                  command: ["/bin/sh", "-ec"],
-                  args: [
-                    "echo \"Waiting for Multus on $${NODE_NAME}\"\nuntil kubectl wait --namespace=kube-system --for=condition=Ready pod --selector=app.kubernetes.io/name=multus-cni --field-selector=spec.nodeName=$${NODE_NAME},status.phase=Running --timeout=10s; do\n  echo \"Multus is not ready on $${NODE_NAME}; retrying\"\n  sleep 5\ndone\n"
-                  ],
-                  env: [
-                    Object.spec.initContainers.env{
-                      name: "NODE_NAME",
-                      value: object.spec.nodeName
-                    }
-                  ],
-                  securityContext: Object.spec.initContainers.securityContext{
-                    allowPrivilegeEscalation: false,
-                    capabilities: Object.spec.initContainers.securityContext.capabilities{
-                      drop: ["ALL"]
-                    },
-                    privileged: false,
-                    readOnlyRootFilesystem: true,
-                    runAsGroup: 101,
-                    runAsNonRoot: true,
-                    runAsUser: 100
+          [
+            JSONPatch{
+              op: "add",
+              path: "/spec/initContainers",
+              value: has(object.spec.initContainers) ? object.spec.initContainers : []
+            },
+            JSONPatch{
+              op: "add",
+              path: "/spec/initContainers/-",
+              value: Object.spec.initContainers{
+                name: "wait-for-multus",
+                image: "docker.io/alpine/kubectl:1.36.2@sha256:9b053116c5c9b746e466230ea3b8bd381757064ee483e236dbadcf7f798f73cf",
+                imagePullPolicy: "IfNotPresent",
+                command: ["/bin/sh", "-ec"],
+                args: [
+                  "echo \"Waiting for Multus on $${NODE_NAME}\"\nuntil kubectl wait --namespace=kube-system --for=condition=Ready pod --selector=app.kubernetes.io/name=multus-cni --field-selector=spec.nodeName=$${NODE_NAME},status.phase=Running --timeout=10s; do\n  echo \"Multus is not ready on $${NODE_NAME}; retrying\"\n  sleep 5\ndone\n"
+                ],
+                env: [
+                  Object.spec.initContainers.env{
+                    name: "NODE_NAME",
+                    value: object.spec.nodeName
                   }
+                ],
+                securityContext: Object.spec.initContainers.securityContext{
+                  allowPrivilegeEscalation: false,
+                  capabilities: Object.spec.initContainers.securityContext.capabilities{
+                    drop: ["ALL"]
+                  },
+                  privileged: false,
+                  readOnlyRootFilesystem: true,
+                  runAsGroup: 101,
+                  runAsNonRoot: true,
+                  runAsUser: 100
                 }
-              ]
+              }
             }
-          }
+          ]
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicyBinding


### PR DESCRIPTION
## Summary

- replace the failing apply-configuration admission mutation with JSON Patch
- preserve any existing init containers before appending `wait-for-multus`

## Root cause

After `k8s-control-1` restarted, Longhorn attempted to recreate its instance-manager Pod. The API server rejected every create request because ApplyConfiguration cannot mutate the init container's atomic `command`, `args`, and `securityContext.capabilities.drop` fields.

## Impact

The control-plane instance-manager Pod does not exist, its InstanceManager CR is in `error`, and attached volumes are degraded while Longhorn retries Pod creation.

## Validation

- actual `flux envsubst --strict` passed
- focused server-side dry-run accepted the Flux-substituted policy and binding
- isolated live API-server admission test injected `wait-for-multus` into a Pod without init containers
- isolated admission test preserved an existing init container and appended `wait-for-multus`
- isolated admission test propagated `k8s-control-1` into the injected `NODE_NAME`
- temporary test policy, binding, namespace, and Pods were removed
- Longhorn Kustomize rendering passed
- `clustertool checkcrypt` passed
- `git diff --check` passed

No production resources were modified during validation. After merge, Flux should update the policy and Longhorn's retry loop should recreate the missing instance-manager Pod.
