### PR TITLE
fix(cloudnative-pg): correct operator namespace

### DIFF
--- a/clusters/main/kubernetes/system/cloudnative-pg/app/namespace.yaml
+++ b/clusters/main/kubernetes/system/cloudnative-pg/app/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: cert-manager
+  name: cloudnative-pg


### PR DESCRIPTION
## Summary

- correct the CloudNativePG namespace manifest from `cert-manager` to `cloudnative-pg`
- allow Flux to create the namespace and then reconcile the CloudNativePG HelmRelease and CRDs

## Problem

The CloudNativePG Kustomization rendered a HelmRelease in the `cloudnative-pg` namespace but created the `cert-manager` namespace instead. On a fresh cluster, Flux therefore failed with:

```text
HelmRelease/cloudnative-pg/cloudnative-pg not found: namespaces "cloudnative-pg" not found
```

Without the operator and its CRDs, every application chart containing CloudNativePG `Cluster` or `ScheduledBackup` resources also failed installation.

## Validation

- [x] Rendered the CloudNativePG application Kustomization
- [x] Confirmed the rendered Namespace and HelmRelease both target `cloudnative-pg`
- [x] Rendered the parent system Kustomization
- [x] Kubernetes client dry-run passed for the complete application render
- [x] Server-side dry-run passed for the exact Namespace
- [x] Server-side schema/admission dry-run passed for the HelmRelease
- [x] `git diff --check`
- [x] `clustertool checkcrypt`

## Expected result

```text
cloudnative-pg Namespace
  -> CloudNativePG HelmRelease
  -> CloudNativePG CRDs and operator
  -> database-backed application HelmReleases can reconcile
```
