### PR TITLE
fix(helmrelease): increase action timeout to 30 minutes

### DIFF
--- a/clusters/main/kubernetes/apps/authentik/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/authentik/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   driftDetection:
     mode: warn

--- a/clusters/main/kubernetes/apps/cloudflareddns/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/cloudflareddns/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   driftDetection:
     mode: warn

--- a/clusters/main/kubernetes/apps/code-server/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/code-server/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   driftDetection:
     mode: warn

--- a/clusters/main/kubernetes/apps/gitea/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/gitea/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   driftDetection:
     mode: warn

--- a/clusters/main/kubernetes/apps/home-assistant/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/home-assistant/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   driftDetection:
     mode: warn

--- a/clusters/main/kubernetes/apps/homepage/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/homepage/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   driftDetection:
     mode: warn

--- a/clusters/main/kubernetes/apps/it-tools/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/it-tools/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   install:
     timeout: 30m
     createNamespace: true

--- a/clusters/main/kubernetes/apps/kubernetes-dashboard/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/kubernetes-dashboard/app/helm-release.yaml
@@ -15,7 +15,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   driftDetection:
     mode: warn

--- a/clusters/main/kubernetes/apps/nextcloud/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/nextcloud/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   driftDetection:
     mode: warn

--- a/clusters/main/kubernetes/apps/ollama/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/ollama/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   driftDetection:
     mode: warn

--- a/clusters/main/kubernetes/apps/protonmail-bridge/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/protonmail-bridge/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   driftDetection:
     mode: warn

--- a/clusters/main/kubernetes/apps/proxmox-gui/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/proxmox-gui/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   driftDetection:
     mode: warn

--- a/clusters/main/kubernetes/apps/static/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/static/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   driftDetection:
     mode: warn

--- a/clusters/main/kubernetes/apps/truenas-gui/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/truenas-gui/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   driftDetection:
     mode: warn

--- a/clusters/main/kubernetes/apps/vaultwarden/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/vaultwarden/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   driftDetection:
     mode: warn

--- a/clusters/main/kubernetes/core/blocky/app/helm-release.yaml
+++ b/clusters/main/kubernetes/core/blocky/app/helm-release.yaml
@@ -16,7 +16,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   install:
     timeout: 30m

--- a/clusters/main/kubernetes/core/clusterissuer/app/helm-release.yaml
+++ b/clusters/main/kubernetes/core/clusterissuer/app/helm-release.yaml
@@ -16,7 +16,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   install:
     timeout: 30m

--- a/clusters/main/kubernetes/core/metallb-config/app/helm-release.yaml
+++ b/clusters/main/kubernetes/core/metallb-config/app/helm-release.yaml
@@ -15,7 +15,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   driftDetection:
     mode: warn

--- a/clusters/main/kubernetes/kube-system/cilium/app/helm-release.yaml
+++ b/clusters/main/kubernetes/kube-system/cilium/app/helm-release.yaml
@@ -19,7 +19,7 @@ spec:
         name: cilium
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   driftDetection:
     mode: warn

--- a/clusters/main/kubernetes/kube-system/descheduler/app/helm-release.yaml
+++ b/clusters/main/kubernetes/kube-system/descheduler/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: home-ops-mirror
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   install:
     timeout: 30m

--- a/clusters/main/kubernetes/kube-system/metrics-server/app/helm-release.yaml
+++ b/clusters/main/kubernetes/kube-system/metrics-server/app/helm-release.yaml
@@ -15,7 +15,7 @@ spec:
         name: home-ops-mirror
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   driftDetection:
     mode: warn

--- a/clusters/main/kubernetes/kube-system/multus/app/helm-release.yaml
+++ b/clusters/main/kubernetes/kube-system/multus/app/helm-release.yaml
@@ -15,7 +15,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   install:
     crds: CreateReplace

--- a/clusters/main/kubernetes/kube-system/node-feature-discovery/app/helm-release.yaml
+++ b/clusters/main/kubernetes/kube-system/node-feature-discovery/app/helm-release.yaml
@@ -15,7 +15,7 @@ spec:
         kind: HelmRepository
         name: node-feature-discovery
         namespace: flux-system
-  timeout: 20m
+  timeout: 30m
   install:
     timeout: 30m
     crds: CreateReplace

--- a/clusters/main/kubernetes/kube-system/whereabouts/app/helm-release.yaml
+++ b/clusters/main/kubernetes/kube-system/whereabouts/app/helm-release.yaml
@@ -15,7 +15,7 @@ spec:
         name: whereabouts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   install:
     timeout: 30m

--- a/clusters/main/kubernetes/media/emby/app/helm-release.yaml
+++ b/clusters/main/kubernetes/media/emby/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   driftDetection:
     mode: warn

--- a/clusters/main/kubernetes/media/flaresolverr/app/helm-release.yaml
+++ b/clusters/main/kubernetes/media/flaresolverr/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   install:
     timeout: 30m

--- a/clusters/main/kubernetes/media/immich/app/helm-release.yaml
+++ b/clusters/main/kubernetes/media/immich/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   driftDetection:
     mode: warn

--- a/clusters/main/kubernetes/media/jellyfin/app/helm-release.yaml
+++ b/clusters/main/kubernetes/media/jellyfin/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   driftDetection:
     mode: warn

--- a/clusters/main/kubernetes/media/lidarr/app/helm-release.yaml
+++ b/clusters/main/kubernetes/media/lidarr/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   driftDetection:
     mode: warn

--- a/clusters/main/kubernetes/media/ombi/app/helm-release.yaml
+++ b/clusters/main/kubernetes/media/ombi/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   driftDetection:
     mode: warn

--- a/clusters/main/kubernetes/media/prowlarr/app/helm-release.yaml
+++ b/clusters/main/kubernetes/media/prowlarr/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   driftDetection:
     mode: warn

--- a/clusters/main/kubernetes/media/qbittorrent/app/helm-release.yaml
+++ b/clusters/main/kubernetes/media/qbittorrent/app/helm-release.yaml
@@ -15,7 +15,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   install:
     timeout: 30m
     createNamespace: true

--- a/clusters/main/kubernetes/media/radarr/app/helm-release.yaml
+++ b/clusters/main/kubernetes/media/radarr/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   driftDetection:
     mode: warn

--- a/clusters/main/kubernetes/media/recyclarr/app/helm-release.yaml
+++ b/clusters/main/kubernetes/media/recyclarr/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   driftDetection:
     mode: warn

--- a/clusters/main/kubernetes/media/sonarr/app/helm-release.yaml
+++ b/clusters/main/kubernetes/media/sonarr/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   driftDetection:
     mode: warn

--- a/clusters/main/kubernetes/networking/nginx-external/app/helm-release.yaml
+++ b/clusters/main/kubernetes/networking/nginx-external/app/helm-release.yaml
@@ -16,7 +16,7 @@ spec:
         name: home-ops-mirror
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   install:
     timeout: 30m

--- a/clusters/main/kubernetes/networking/nginx-internal/app/helm-release.yaml
+++ b/clusters/main/kubernetes/networking/nginx-internal/app/helm-release.yaml
@@ -16,7 +16,7 @@ spec:
         name: home-ops-mirror
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   install:
     timeout: 30m

--- a/clusters/main/kubernetes/observability/alloy/app/helm-release.yaml
+++ b/clusters/main/kubernetes/observability/alloy/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: home-ops-mirror
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   install:
     timeout: 30m
     createNamespace: true

--- a/clusters/main/kubernetes/observability/gatus/app/helm-release.yaml
+++ b/clusters/main/kubernetes/observability/gatus/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   install:
     timeout: 30m
     createNamespace: true

--- a/clusters/main/kubernetes/observability/grafana/app/helm-release.yaml
+++ b/clusters/main/kubernetes/observability/grafana/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   driftDetection:
     mode: warn

--- a/clusters/main/kubernetes/observability/headlamp/app/helm-release.yaml
+++ b/clusters/main/kubernetes/observability/headlamp/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: home-ops-mirror
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   driftDetection:
     mode: warn

--- a/clusters/main/kubernetes/observability/kromgo/app/helm-release.yaml
+++ b/clusters/main/kubernetes/observability/kromgo/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   install:
     timeout: 30m
     createNamespace: true

--- a/clusters/main/kubernetes/observability/kube-prometheus-stack/app/helm-release.yaml
+++ b/clusters/main/kubernetes/observability/kube-prometheus-stack/app/helm-release.yaml
@@ -16,7 +16,7 @@ spec:
         name: prometheus-community
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   install:
     createNamespace: true

--- a/clusters/main/kubernetes/observability/loki/app/helm-release.yaml
+++ b/clusters/main/kubernetes/observability/loki/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: grafana
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   install:
     timeout: 30m
     createNamespace: true

--- a/clusters/main/kubernetes/observability/truenas-exporter/app/helm-release.yaml
+++ b/clusters/main/kubernetes/observability/truenas-exporter/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   driftDetection:
     mode: warn

--- a/clusters/main/kubernetes/observability/unpoller/app/helm-release.yaml
+++ b/clusters/main/kubernetes/observability/unpoller/app/helm-release.yaml
@@ -16,7 +16,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   install:
     timeout: 30m

--- a/clusters/main/kubernetes/system/cert-manager/app/helm-release.yaml
+++ b/clusters/main/kubernetes/system/cert-manager/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: jetstack
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   install:
     timeout: 30m
     createNamespace: true

--- a/clusters/main/kubernetes/system/cloudnative-pg/app/helm-release.yaml
+++ b/clusters/main/kubernetes/system/cloudnative-pg/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: cloudnative-pg
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   install:
     timeout: 30m
     createNamespace: true

--- a/clusters/main/kubernetes/system/generic-device-plugin/app/helm-release.yaml
+++ b/clusters/main/kubernetes/system/generic-device-plugin/app/helm-release.yaml
@@ -15,7 +15,7 @@ spec:
                 name: truecharts
                 namespace: flux-system
             interval: 15m
-    timeout: 20m
+    timeout: 30m
     install:
         timeout: 30m
         createNamespace: true

--- a/clusters/main/kubernetes/system/intel-device-plugin-gpu/app/helm-release.yaml
+++ b/clusters/main/kubernetes/system/intel-device-plugin-gpu/app/helm-release.yaml
@@ -15,7 +15,7 @@ spec:
         kind: HelmRepository
         name: home-ops-mirror
         namespace: flux-system
-  timeout: 20m
+  timeout: 30m
   install:
     timeout: 30m
     remediation:

--- a/clusters/main/kubernetes/system/intel-device-plugin-operator/app/helm-release.yaml
+++ b/clusters/main/kubernetes/system/intel-device-plugin-operator/app/helm-release.yaml
@@ -15,7 +15,7 @@ spec:
         kind: HelmRepository
         name: home-ops-mirror
         namespace: flux-system
-  timeout: 20m
+  timeout: 30m
   install:
     timeout: 30m
     crds: CreateReplace

--- a/clusters/main/kubernetes/system/kubernetes-reflector/app/helm-release.yaml
+++ b/clusters/main/kubernetes/system/kubernetes-reflector/app/helm-release.yaml
@@ -15,7 +15,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   maxHistory: 3
   driftDetection:
     mode: warn

--- a/clusters/main/kubernetes/system/longhorn/app/helm-release.yaml
+++ b/clusters/main/kubernetes/system/longhorn/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         kind: HelmRepository
         name: home-ops-mirror
         namespace: flux-system
-  timeout: 20m
+  timeout: 30m
   install:
     timeout: 30m
     createNamespace: true

--- a/clusters/main/kubernetes/system/metallb/app/helm-release.yaml
+++ b/clusters/main/kubernetes/system/metallb/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: metallb
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   install:
     timeout: 30m
     createNamespace: true

--- a/clusters/main/kubernetes/system/openebs/app/helm-release.yaml
+++ b/clusters/main/kubernetes/system/openebs/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         kind: HelmRepository
         name: openebs
         namespace: flux-system
-  timeout: 20m
+  timeout: 30m
   install:
     timeout: 30m
     createNamespace: true

--- a/clusters/main/kubernetes/system/snapshot-controller/app/helm-release.yaml
+++ b/clusters/main/kubernetes/system/snapshot-controller/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   install:
     timeout: 30m
     createNamespace: true

--- a/clusters/main/kubernetes/system/spegel/app/helm-release.yaml
+++ b/clusters/main/kubernetes/system/spegel/app/helm-release.yaml
@@ -15,7 +15,7 @@ spec:
         kind: HelmRepository
         name: truecharts
         namespace: flux-system
-  timeout: 20m
+  timeout: 30m
   install:
     timeout: 30m
     remediation:

--- a/clusters/main/kubernetes/system/volsync/app/helm-release.yaml
+++ b/clusters/main/kubernetes/system/volsync/app/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: truecharts
         namespace: flux-system
       interval: 15m
-  timeout: 20m
+  timeout: 30m
   install:
     timeout: 30m
     createNamespace: true


### PR DESCRIPTION
## Summary

- raise the HelmRelease-wide action timeout from 20 minutes to 30 minutes
- apply the timeout consistently across all 58 HelmRelease manifests that define an explicit action timeout
- retain the existing 30-minute install-specific overrides

## Context

Authentik's install action was already configured and observed by `helm-controller` with a 30-minute timeout. The current recovery attempt failed earlier because `Deployment/authentik/authentik-ldap` entered a stalled state after about 10 minutes, so this consistency change does not by itself address that early Deployment stall.

## Validation

- `git diff --check`
- rendered every changed app kustomization with `kubectl kustomize`
- server-side dry-run validated all 58 changed HelmRelease manifests against the live API server
- confirmed no changed HelmRelease manifest retains a 20-minute explicit action timeout
