### PR TITLE
fix(immich): initialize restored storage markers

### DIFF
--- a/clusters/main/kubernetes/media/immich/app/helm-release.yaml
+++ b/clusters/main/kubernetes/media/immich/app/helm-release.yaml
@@ -75,6 +75,33 @@ spec:
             enabled: true
           nginx:
             enabled: true
+    workload:
+      main:
+        podSpec:
+          initContainers:
+            initialize-storage-markers:
+              enabled: true
+              type: init
+              imageSelector: image
+              securityContext:
+                capabilities:
+                  disableS6Caps: true
+              command:
+                - /bin/sh
+                - -ec
+                - |
+                  for directory in \
+                    /usr/src/app/upload/encoded-video \
+                    /usr/src/app/upload/library \
+                    /usr/src/app/upload/upload \
+                    /usr/src/app/upload/profile \
+                    /usr/src/app/upload/thumbs \
+                    /usr/src/app/upload/backups; do
+                    if [ ! -f "$${directory}/.immich" ]; then
+                      echo "Creating Immich storage marker in $${directory}"
+                      touch "$${directory}/.immich"
+                    fi
+                  done
     persistence:
       library:
         enabled: true
@@ -82,3 +109,26 @@ spec:
         readOnly: false
         server: ${TRUENAS_IP}
         type: nfs
+        targetSelector:
+          main:
+            initialize-storage-markers: {}
+      uploads:
+        targetSelector:
+          main:
+            initialize-storage-markers: {}
+      backups:
+        targetSelector:
+          main:
+            initialize-storage-markers: {}
+      thumbs:
+        targetSelector:
+          main:
+            initialize-storage-markers: {}
+      profile:
+        targetSelector:
+          main:
+            initialize-storage-markers: {}
+      video:
+        targetSelector:
+          main:
+            initialize-storage-markers: {}


### PR DESCRIPTION
## Summary

- add an idempotent Immich storage-marker init container to the main workload
- mount all six Immich-managed storage directories into the initializer
- create missing `.immich` marker files before the API server starts
- reuse the pinned Immich image and drop all Linux capabilities for the initializer

## Problem

After CloudNativePG restores the existing Immich database, its persisted `mountChecks` state says all storage locations have already been initialized. The newly provisioned storage volumes are empty, however, so Immich v3.1.0 fails closed during startup:

```text
Failed to read (/usr/src/app/upload/encoded-video/.immich):
ENOENT: no such file or directory
```

All six required Immich storage directories were present as chart volume mounts but lacked their `.immich` markers:

- `encoded-video`
- `library`
- `upload`
- `profile`
- `thumbs`
- `backups`

## Fix

The main Immich pod now initializes a missing `.immich` marker in each mounted directory before the API container starts. The operation is idempotent and does not overwrite existing markers. Machine-learning and microservices already wait for the main server, so they remain gated until initialization and API startup succeed.

The shell variable is written as `$${directory}` in Git so Flux post-build substitution emits the intended literal `${directory}` in the HelmRelease value.

## Validation

- [x] Reproduced the exact Immich v3.1.0 `ImmichStartupError` against the restored database
- [x] Confirmed all six live storage mounts were empty and missing `.immich`
- [x] Inspected the pinned Immich image and verified `/bin/sh` and `/usr/bin/touch`
- [x] Verified read/write/delete access against all six exact live mounts using the chart's `fsGroup: 568`
- [x] Executed the marker script successfully against six isolated mounted directories
- [x] Rendered and linted exact TrueCharts `immich` chart `33.7.1`
- [x] Confirmed exactly one initializer with all six required mounts
- [x] Confirmed initializer adds no Linux capabilities and drops `ALL`
- [x] Confirmed existing main and microservices application volume mounts are unchanged
- [x] Confirmed non-main resources are unchanged except expected persistence rollout checksums
- [x] Server-side dry-run passed for the exact rendered chart output
- [x] Immich application and media Kustomize renders passed
- [x] `git diff --check`
- [x] `clustertool checkcrypt`

## Expected result

```text
storage volumes mounted
  -> missing .immich markers created
  -> Immich storage integrity checks pass
  -> API server becomes Ready
  -> microservices and machine learning start
```
