### PR TITLE
fix(talos): allow safe Longhorn node drains

### DIFF
--- a/clusters/main/kubernetes/system/longhorn/app/helm-release.yaml
+++ b/clusters/main/kubernetes/system/longhorn/app/helm-release.yaml
@@ -49,7 +49,9 @@ spec:
       # Overprovisioning might be needed when using volsync
       storageOverProvisioningPercentage: "100000"
       v2DataEngine: false
-      nodeDrainPolicy: allow-if-replica-is-stopped
+      # Permit maintenance when another healthy replica exists, but continue to
+      # block draining a node that contains a volume's last healthy replica.
+      nodeDrainPolicy: block-if-contains-last-replica
     persistence:
       # Set to false to pick another CSI as default
       defaultClass: true

--- a/clusters/main/kubernetes/system/longhorn/config/app/kustomization.yaml
+++ b/clusters/main/kubernetes/system/longhorn/config/app/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - node-drain-policy.yaml
   - volumeSnapshotClass.yaml
   - jobs

--- a/clusters/main/kubernetes/system/longhorn/config/app/node-drain-policy.yaml
+++ b/clusters/main/kubernetes/system/longhorn/config/app/node-drain-policy.yaml
@@ -1,0 +1,6 @@
+apiVersion: longhorn.io/v1beta2
+kind: Setting
+metadata:
+  name: node-drain-policy
+  namespace: longhorn-system
+value: block-if-contains-last-replica

--- a/clusters/main/kubernetes/system/system-upgrade/tuppr-plans/app/talos.yaml
+++ b/clusters/main/kubernetes/system/system-upgrade/tuppr-plans/app/talos.yaml
@@ -14,11 +14,22 @@ spec:
     rebootMode: default  # Optional, default|powercycle
     placement: soft      # Optional, hard|soft
     timeout: 1h          # Allow slow post-upgrade node reboots to complete
-    waitForVolumeDetach: false
+    # Drain before starting the Talos upgrade, wait for CSI detach, and roll
+    # back the cordon if the pre-upgrade drain cannot complete safely.
+    waitForVolumeDetach: true
 
-  # A degraded attached Longhorn volume can make its instance-manager PDB
-  # unevictable. Do not begin an upgrade until every attached volume is healthy.
   healthChecks:
+    # Gate retries on the live Setting, not only on Flux dependency readiness,
+    # so the safer policy must be active before any node drain begins.
+    - apiVersion: longhorn.io/v1beta2
+      kind: Setting
+      name: node-drain-policy
+      namespace: longhorn-system
+      description: Longhorn allows drains when a healthy replica remains
+      expr: object.value == "block-if-contains-last-replica"
+      timeout: 10m
+    # A degraded attached Longhorn volume can make its instance-manager PDB
+    # unevictable. Do not begin an upgrade until every attached volume is healthy.
     - apiVersion: longhorn.io/v1beta2
       kind: Volume
       namespace: longhorn-system

--- a/clusters/main/kubernetes/system/system-upgrade/tuppr-plans/ks.yaml
+++ b/clusters/main/kubernetes/system/system-upgrade/tuppr-plans/ks.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   dependsOn:
     - name: tuppr
+    # Apply Longhorn's live drain policy before a TalosUpgrade spec change can
+    # trigger another maintenance attempt.
+    - name: longhorn-config
   interval: 1h
   path: clusters/main/kubernetes/system/system-upgrade/tuppr-plans/app
   prune: true


### PR DESCRIPTION
## Summary

- change Longhorn's node drain policy from `allow-if-replica-is-stopped` to `block-if-contains-last-replica`
- reconcile the policy as an explicit Longhorn `Setting` so the existing cluster is updated, while retaining the Helm default for clean installs
- make TUPPR own the pre-upgrade drain and wait up to two minutes for CSI volume detach before launching `talosctl upgrade`
- order `tuppr-plans` after `longhorn-config` and add a live-setting health gate so the safer policy is active before the `TalosUpgrade` spec change can begin draining nodes

TUPPR 0.4.7's CSI `VolumeAttachment` wait is bounded and best-effort: it proceeds after the timeout. The PDB-respecting drain plus the live Longhorn policy and attached-volume health gates remain the fail-closed safety checks; upgrade logs should still be monitored for `Volumes did not detach before timeout`.

## Root cause

Talos `v1.13.8` was installed successfully during both attempts, but the node never rebooted. Talos's built-in drain timed out evicting the control-node Longhorn instance-manager because its PDB allowed zero disruptions.

The cluster has two replicas per Longhorn volume, with one healthy replica on each node, but `allow-if-replica-is-stopped` protects every running replica even when a healthy counterpart exists. This deadlocks maintenance in the two-node/two-replica topology.

`block-if-contains-last-replica` preserves last-healthy-copy protection while allowing maintenance when another healthy replica exists. This PR does not reduce the Longhorn replica count and does not use `always-allow` or force PDB bypasses.

## Validation

- rendered the Longhorn app, Longhorn CRD-dependent config, TUPPR plan, system-upgrade, and complete system Kustomizations
- passed server-side dry-run for the Longhorn app, explicit Longhorn `Setting`, system-upgrade Kustomization, and `TalosUpgrade`
- passed a Flux-equivalent forced server-side apply dry-run for taking ownership of the existing Longhorn `Setting` value
- linted and rendered the exact Flux-cached Longhorn chart `1.12.0`
- asserted the rendered `longhorn-default-setting` contains `block-if-contains-last-replica`
- passed server-side dry-run for the exact rendered Longhorn chart with a substituted validation hostname
- asserted the explicit live `Setting` value, live-setting health gate, `waitForVolumeDetach: true`, and `tuppr-plans` dependencies
- passed `git diff --check`
- passed `clustertool checkcrypt`

## Post-merge verification

1. Confirm the live `node-drain-policy` Setting becomes `block-if-contains-last-replica` before TUPPR retries.
2. Confirm the control-node instance-manager PDB becomes evictable once every affected volume has a healthy counterpart.
3. Verify TUPPR performs the pre-upgrade drain and invokes Talos with duplicate draining disabled.
4. Verify `k8s-control-1` reboots into `v1.13.8`, returns Ready and schedulable, and all Longhorn volumes return healthy.
5. Verify the worker upgrades only after the control-plane node succeeds.
