### PR TITLE
chore(longhorn): remove redundant drain setting

### DIFF
--- a/clusters/main/kubernetes/system/longhorn/config/app/kustomization.yaml
+++ b/clusters/main/kubernetes/system/longhorn/config/app/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - node-drain-policy.yaml
   - volumeSnapshotClass.yaml
   - jobs

--- a/clusters/main/kubernetes/system/longhorn/config/app/node-drain-policy.yaml
+++ b/clusters/main/kubernetes/system/longhorn/config/app/node-drain-policy.yaml
@@ -1,6 +1,0 @@
-apiVersion: longhorn.io/v1beta2
-kind: Setting
-metadata:
-  name: node-drain-policy
-  namespace: longhorn-system
-value: block-if-contains-last-replica


### PR DESCRIPTION
## Summary

- remove the redundant explicit `longhorn.io/v1beta2` `Setting` manifest for `node-drain-policy`
- keep `defaultSettings.nodeDrainPolicy: block-if-contains-last-replica` in the Longhorn HelmRelease as the authoritative configuration
- retain TUPPR's live-setting health check and Longhorn configuration dependency

## Reconciliation behavior

`longhorn-config` has pruning enabled, so merging this change removes the currently inventoried `node-drain-policy` Setting CR. Longhorn 1.12.0 keeps using the customized default from `longhorn-default-setting`; its manager startup or a subsequent default-settings ConfigMap update recreates a missing Setting CR with `block-if-contains-last-replica`.

Until that CR is recreated, TUPPR's named live-setting health check intentionally blocks another Talos upgrade rather than proceeding without proving the effective policy. Merge this cleanup when a Longhorn reinstall/manager restart is planned or acceptable, and verify the Setting is recreated before the next node-maintenance run.

## Validation

- rendered the Longhorn installer, Longhorn post-CRD config, and complete system Kustomizations
- verified the Longhorn config render no longer contains an explicit `Setting`
- passed server-side dry-run for the remaining Longhorn config resources
- verified the HelmRelease still sets `defaultSettings.nodeDrainPolicy` to `block-if-contains-last-replica`
- verified TUPPR's fail-closed live-setting health check remains
- inspected Longhorn manager `v1.12.0` source: customized defaults update existing settings, manager initialization creates missing Setting CRs, and missing settings are read using the customized in-process default
- passed `git diff --check`
- passed `clustertool checkcrypt`

## Post-merge verification

1. Confirm Flux prunes the explicitly managed Setting.
2. After Longhorn manager restart/reinstall, confirm `node-drain-policy` is recreated as `block-if-contains-last-replica` and reports `status.applied: true`.
3. Confirm the Longhorn HelmRelease and `longhorn-config` Kustomization remain Ready.
4. Before another Talos upgrade, confirm TUPPR's named Setting health check passes.
