### PR TITLE
fix(longhorn): preserve drain setting during handoff

### DIFF
--- a/clusters/main/kubernetes/system/longhorn/config/app/kustomization.yaml
+++ b/clusters/main/kubernetes/system/longhorn/config/app/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - node-drain-policy.yaml
   - volumeSnapshotClass.yaml
   - jobs

--- a/clusters/main/kubernetes/system/longhorn/config/app/node-drain-policy.yaml
+++ b/clusters/main/kubernetes/system/longhorn/config/app/node-drain-policy.yaml
@@ -1,0 +1,10 @@
+apiVersion: longhorn.io/v1beta2
+kind: Setting
+metadata:
+  name: node-drain-policy
+  namespace: longhorn-system
+  annotations:
+    # Longhorn's admission webhook forbids deleting Setting CRs. Orphan this
+    # object rather than letting Flux attempt an impossible prune on handoff.
+    kustomize.toolkit.fluxcd.io/prune: disabled
+value: block-if-contains-last-replica


### PR DESCRIPTION
## Summary

- reintroduce the Git-managed Longhorn `node-drain-policy` Setting so Flux stops trying to prune an object that Longhorn forbids deleting
- annotate the Setting with `kustomize.toolkit.fluxcd.io/prune: disabled` so a future ownership handoff orphans it instead of repeating the failed deletion
- keep the live and Helm-managed policy aligned at `block-if-contains-last-replica`

## Root cause

The previous cleanup removed the Setting manifest while `longhorn-config.spec.prune` remained enabled. Flux retained the object in its inventory and attempted to delete it, but Longhorn's validating webhook rejects deletion of Setting CRs. This leaves `longhorn-config` in `PruneFailed` and blocks the dependent `tuppr-plans` Kustomization.

## Validation

- rendered the complete Longhorn post-install configuration
- passed server-side dry-run for all rendered Longhorn config resources using Flux's field manager and force-conflict semantics
- rendered the parent `system` Kustomization and confirmed both Longhorn Kustomizations and `tuppr-plans` remain present
- asserted the Setting renders with `prune: disabled` and value `block-if-contains-last-replica`
- verified the HelmRelease still declares two replicas and the same drain policy
- verified TUPPR still owns volume detach and retains its fail-closed live Setting health check
- passed `git diff --check`
- passed `clustertool checkcrypt`

## Post-merge verification

1. Confirm `longhorn-config` returns to Ready and no longer reports `PruneFailed`.
2. Confirm `tuppr-plans` is no longer blocked by `DependencyNotReady`.
3. Confirm the live Setting remains `block-if-contains-last-replica` and carries the prune-disabled annotation.
4. Leave Talos upgrades sequential and verify a future maintenance run through the full drain/reboot path.
