### PR TITLE
fix(longhorn): recover failed bootstrap install

### DIFF
--- a/clusters/main/kubernetes/networking/nginx-internal/ks.yaml
+++ b/clusters/main/kubernetes/networking/nginx-internal/ks.yaml
@@ -10,4 +10,6 @@ spec:
   sourceRef:
     kind: GitRepository
     name: cluster
+  timeout: 10m
+  wait: true
 

--- a/clusters/main/kubernetes/system/kustomization.yaml
+++ b/clusters/main/kubernetes/system/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - cert-manager/ks.yaml
   - cloudnative-pg/ks.yaml
   - kubernetes-reflector/ks.yaml
+  - longhorn/recovery/ks.yaml
   - longhorn/ks.yaml
   - longhorn/config/ks.yaml
   - metallb/ks.yaml

--- a/clusters/main/kubernetes/system/longhorn/app/helm-release.yaml
+++ b/clusters/main/kubernetes/system/longhorn/app/helm-release.yaml
@@ -19,8 +19,9 @@ spec:
     timeout: 30m
     createNamespace: true
     crds: CreateReplace
-    remediation:
-      retries: 3
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 5m
   upgrade:
     crds: CreateReplace
     remediation:

--- a/clusters/main/kubernetes/system/longhorn/ks.yaml
+++ b/clusters/main/kubernetes/system/longhorn/ks.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   dependsOn:
     - name: multus
+    - name: nginx-external
+    - name: nginx-internal
     - name: snapshot-controller
   interval: 10m
   path: clusters/main/kubernetes/system/longhorn/app

--- a/clusters/main/kubernetes/system/longhorn/recovery/app/job.yaml
+++ b/clusters/main/kubernetes/system/longhorn/recovery/app/job.yaml
@@ -1,0 +1,148 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: longhorn-helm-recovery-v1
+  namespace: longhorn-system
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      automountServiceAccountToken: true
+      containers:
+        - name: recover
+          image: docker.io/library/python:3.13-alpine@sha256:399babc8b49529dabfd9c922f2b5eea81d611e4512e3ed250d75bd2e7683f4b0
+          command:
+            - python3
+            - -c
+          args:
+            - |
+              import json
+              import ssl
+              import time
+              import urllib.error
+              import urllib.request
+
+              namespace = "longhorn-system"
+              secret_name = "sh.helm.release.v1.longhorn.v1"
+              token_path = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+              ca_path = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+              api = "https://kubernetes.default.svc"
+              token = open(token_path, encoding="utf-8").read()
+              context = ssl.create_default_context(cafile=ca_path)
+
+              def request(method, path, body=None):
+                  data = None if body is None else json.dumps(body).encode()
+                  req = urllib.request.Request(
+                      api + path,
+                      data=data,
+                      method=method,
+                      headers={
+                          "Authorization": "Bearer " + token,
+                          "Accept": "application/json",
+                          "Content-Type": "application/json",
+                      },
+                  )
+                  with urllib.request.urlopen(req, context=context, timeout=10) as response:
+                      return json.load(response)
+
+              release_path = (
+                  "/apis/helm.toolkit.fluxcd.io/v2/namespaces/"
+                  + namespace
+                  + "/helmreleases/longhorn"
+              )
+              while True:
+                  try:
+                      release = request("GET", release_path)
+                      strategy = (
+                          release.get("spec", {})
+                          .get("install", {})
+                          .get("strategy", {})
+                          .get("name")
+                      )
+                  except urllib.error.HTTPError as error:
+                      if error.code != 404:
+                          raise
+                      strategy = None
+
+                  if strategy == "RetryOnFailure":
+                      break
+                  print("Waiting for the safe Longhorn install strategy", flush=True)
+                  time.sleep(5)
+
+              secret_path = "/api/v1/namespaces/{}/secrets/{}".format(
+                  namespace, secret_name
+              )
+              try:
+                  secret = request("GET", secret_path)
+              except urllib.error.HTTPError as error:
+                  if error.code == 404:
+                      print("No Helm release recovery is required")
+                      raise SystemExit(0)
+                  raise
+
+              metadata = secret.get("metadata", {})
+              labels = metadata.get("labels", {})
+              identity = (
+                  metadata.get("namespace"),
+                  metadata.get("name"),
+                  secret.get("type"),
+                  labels.get("owner"),
+                  labels.get("name"),
+                  labels.get("version"),
+                  labels.get("status"),
+              )
+              expected = (
+                  namespace,
+                  secret_name,
+                  "helm.sh/release.v1",
+                  "helm",
+                  "longhorn",
+                  "1",
+                  "uninstalling",
+              )
+              if identity != expected:
+                  raise RuntimeError("refusing to delete unexpected Helm state: {!r}".format(identity))
+
+              uid = metadata.get("uid")
+              resource_version = metadata.get("resourceVersion")
+              if not uid or not resource_version:
+                  raise RuntimeError(
+                      "refusing to delete Helm state without UID and resourceVersion"
+                  )
+
+              request(
+                  "DELETE",
+                  secret_path,
+                  {
+                      "apiVersion": "v1",
+                      "kind": "DeleteOptions",
+                      "preconditions": {
+                          "uid": uid,
+                          "resourceVersion": resource_version,
+                      },
+                  },
+              )
+              print(
+                  "Removed the stale Longhorn Helm v1 release record; "
+                  "live Longhorn resources were left intact"
+              )
+          env:
+            - name: PYTHONDONTWRITEBYTECODE
+              value: "1"
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 101
+            runAsNonRoot: true
+            runAsUser: 100
+      restartPolicy: Never
+      serviceAccountName: longhorn-helm-recovery

--- a/clusters/main/kubernetes/system/longhorn/recovery/app/kustomization.yaml
+++ b/clusters/main/kubernetes/system/longhorn/recovery/app/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rbac.yaml
+  - job.yaml

--- a/clusters/main/kubernetes/system/longhorn/recovery/app/rbac.yaml
+++ b/clusters/main/kubernetes/system/longhorn/recovery/app/rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: longhorn-helm-recovery
+  namespace: longhorn-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: longhorn-helm-recovery
+  namespace: longhorn-system
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    resourceNames:
+      - sh.helm.release.v1.longhorn.v1
+    verbs:
+      - get
+      - delete
+  - apiGroups:
+      - helm.toolkit.fluxcd.io
+    resources:
+      - helmreleases
+    resourceNames:
+      - longhorn
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: longhorn-helm-recovery
+  namespace: longhorn-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: longhorn-helm-recovery
+subjects:
+  - kind: ServiceAccount
+    name: longhorn-helm-recovery
+    namespace: longhorn-system

--- a/clusters/main/kubernetes/system/longhorn/recovery/ks.yaml
+++ b/clusters/main/kubernetes/system/longhorn/recovery/ks.yaml
@@ -1,15 +1,17 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: nginx-external
+  name: longhorn-helm-recovery
   namespace: flux-system
 spec:
+  dependsOn:
+    - name: nginx-external
+    - name: nginx-internal
   interval: 10m
-  path: clusters/main/kubernetes/networking/nginx-external/app
+  path: clusters/main/kubernetes/system/longhorn/recovery/app
   prune: true
   sourceRef:
     kind: GitRepository
     name: cluster
-  timeout: 10m
+  timeout: 5m
   wait: true
-


### PR DESCRIPTION
## Summary

- make both ingress-nginx Kustomizations wait for workload health, then gate Longhorn reconciliation on them
- coordinate a one-time Helm metadata recovery after the safer install strategy is live
- remove only the exact stale `sh.helm.release.v1.longhorn.v1` Secret when its labels prove it is the current `helm/longhorn/1/uninstalling` record
- switch Longhorn installs to Flux `RetryOnFailure` so transient admission failures retry without invoking Longhorn's uninstall hook

## Root cause

During bootstrap, the Longhorn chart tried to create its Ingress before the `nginx-external` admission Service had endpoints. The install failed, Flux's default `RemediateOnFailure` path invoked Longhorn's uninstall hook, and that hook failed. Helm is now stuck with release v1 in `uninstalling`, so the `longhorn` Kustomization is not Ready and `longhorn-config` correctly refuses to reconcile.

The admission endpoints are healthy now, but helm-controller v1.6.3 rejects `uninstalling` as an indeterminate release state and cannot recover without removing the stale Helm metadata record.

## Recovery behavior

`longhorn-helm-recovery-v1` is deliberately fail-closed:

- its Role can only `get` and `delete` `sh.helm.release.v1.longhorn.v1`
- it can only read the `longhorn` HelmRelease and waits until Flux has applied `RetryOnFailure`
- it requires the exact namespace, name, Secret type, and label tuple `helm/longhorn/1/uninstalling`
- it uses the validated Secret UID and resourceVersion as Kubernetes deletion preconditions, so replacement or in-place mutation races fail safely
- any other existing Secret state fails the Job without deleting anything
- it deletes Helm's failed release record only; it does not delete Longhorn workloads, CRDs, volumes, replicas, or PVCs
- the `longhorn` Kustomization waits for both ingress admission controllers before applying the safer HelmRelease configuration
- the recovery Job cannot remove Helm metadata until that safer configuration is visible

Once the stale record is gone, Flux can perform a same-name install and take ownership of the live Longhorn resources. The now-ready admission webhooks no longer block the chart Ingress.

## Validation

- [x] rendered `clusters/main/kubernetes/system/longhorn/recovery/app`
- [x] rendered `clusters/main/kubernetes/system/longhorn/app`
- [x] rendered both ingress-nginx Kustomizations with health waiting enabled
- [x] rendered `clusters/main/kubernetes/system`
- [x] rendered the full `clusters/main/kubernetes` tree
- [x] exact Longhorn `1.12.0` chart lint and render passed with the HelmRelease values
- [x] Flux-equivalent forced server-side dry-run passed for the recovery resources, both affected Flux Kustomizations, and the Longhorn HelmRelease
- [x] recovery shell syntax passed after accounting for Flux `$${...}` escaping
- [x] exact Helm release labels and both live ingress admission endpoint sets were verified
- [x] `git diff --check`
- [x] `clustertool checkcrypt`

## Post-merge verification

After reconciliation, verify:

1. Longhorn receives the `RetryOnFailure` install strategy.
2. `longhorn-helm-recovery` completes successfully.
3. the Longhorn HelmRelease becomes Ready with a new deployed release record.
4. `longhorn`, then `longhorn-config`, then `tuppr-plans` become Ready.
5. Longhorn volume attachments and application mounts recover.
6. the one-time recovery Kustomization and RBAC are removed in a focused cleanup PR.

This PR does not merge itself and does not perform any live deletion before merge.
